### PR TITLE
Add optional listActionsBuilder to ListDetailLayout (#168)

### DIFF
--- a/lib/ui/list_detail/screen.dart
+++ b/lib/ui/list_detail/screen.dart
@@ -11,6 +11,7 @@ class ListDetailLayout extends StatefulWidget {
   final bool showEmptyHint;
   final List<Widget>? Function(BuildContext context, int? selectedIndex)?
   actionsBuilder;
+  final List<Widget>? Function(BuildContext context)? listActionsBuilder;
 
   const ListDetailLayout({
     super.key,
@@ -21,6 +22,7 @@ class ListDetailLayout extends StatefulWidget {
     this.form,
     this.showEmptyHint = true,
     this.actionsBuilder,
+    this.listActionsBuilder,
   });
 
   @override
@@ -85,59 +87,68 @@ class _ListDetailLayoutState extends State<ListDetailLayout> {
             Flexible(
               flex: 1,
               fit: FlexFit.tight,
-              child: Stack(
+              child: Column(
                 children: [
-                  widget.items.isEmpty
-                      ? SizedBox.expand(
-                          child: Column(
-                            children: [
-                              const Padding(padding: EdgeInsets.all(16.0)),
-                              widget.showEmptyHint
-                                  ? emptyHint
-                                  : const SizedBox.shrink(),
-                            ],
-                          ),
-                        )
-                      : ListView(
-                          children: widget.items
-                              .map(
-                                (e) => Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    vertical: 4,
-                                  ),
-                                  child: ListTile(
-                                    title: e.title,
-                                    subtitle: e.subtitle,
-                                    leading: e.leading,
-                                    selected:
-                                        widget.items.indexOf(e) ==
-                                        _selectedIndex,
-                                    onTap: () {
-                                      setState(() {
-                                        _selectedIndex = widget.items.indexOf(
-                                          e,
-                                        );
-                                      });
-                                    },
-                                  ),
+                  if (widget.listActionsBuilder != null)
+                    Row(children: widget.listActionsBuilder!(context) ?? []),
+                  Expanded(
+                    child: Stack(
+                      children: [
+                        widget.items.isEmpty
+                            ? SizedBox.expand(
+                                child: Column(
+                                  children: [
+                                    const Padding(
+                                      padding: EdgeInsets.all(16.0),
+                                    ),
+                                    widget.showEmptyHint
+                                        ? emptyHint
+                                        : const SizedBox.shrink(),
+                                  ],
                                 ),
                               )
-                              .toList(),
-                        ),
-                  if (widget.form != null)
-                    Positioned(
-                      bottom: 0,
-                      right: 0,
-                      child: FloatingActionButton(
-                        onPressed: () {
-                          setState(() {
-                            _selectedIndex = null;
-                            _showForm = true;
-                          });
-                        },
-                        child: const Icon(Icons.add),
-                      ),
+                            : ListView(
+                                children: widget.items
+                                    .map(
+                                      (e) => Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          vertical: 4,
+                                        ),
+                                        child: ListTile(
+                                          title: e.title,
+                                          subtitle: e.subtitle,
+                                          leading: e.leading,
+                                          selected:
+                                              widget.items.indexOf(e) ==
+                                              _selectedIndex,
+                                          onTap: () {
+                                            setState(() {
+                                              _selectedIndex = widget.items
+                                                  .indexOf(e);
+                                            });
+                                          },
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                        if (widget.form != null)
+                          Positioned(
+                            bottom: 0,
+                            right: 0,
+                            child: FloatingActionButton(
+                              onPressed: () {
+                                setState(() {
+                                  _selectedIndex = null;
+                                  _showForm = true;
+                                });
+                              },
+                              child: const Icon(Icons.add),
+                            ),
+                          ),
+                      ],
                     ),
+                  ),
                 ],
               ),
             ),

--- a/test/widget/list_detail_layout_test.dart
+++ b/test/widget/list_detail_layout_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:julog/ui/list_detail/list_detail.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+ListDetailLayout _minimal({
+  List<Widget>? Function(BuildContext)? listActionsBuilder,
+}) {
+  return ListDetailLayout(
+    items: const [],
+    detailBuilder: (_, _) => const SizedBox(),
+    showEmptyHint: false,
+    listActionsBuilder: listActionsBuilder,
+  );
+}
+
+void main() {
+  group('ListDetailLayout listActionsBuilder', () {
+    testWidgets('null: no header row rendered', (tester) async {
+      await tester.pumpWidget(_wrap(_minimal(listActionsBuilder: null)));
+
+      expect(find.byKey(const Key('list_header_row')), findsNothing);
+      expect(find.byType(IconButton), findsNothing);
+    });
+
+    testWidgets('non-null: header row with returned widgets rendered', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          _minimal(
+            listActionsBuilder: (_) => [
+              IconButton(
+                key: const Key('export_btn'),
+                onPressed: () {},
+                icon: const Icon(Icons.download),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('export_btn')), findsOneWidget);
+    });
+
+    testWidgets('non-null returning null: renders empty row gracefully', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(_minimal(listActionsBuilder: (_) => null)));
+
+      expect(find.byType(Row), findsWidgets);
+    });
+
+    testWidgets(
+      'list pane still shows items when listActionsBuilder provided',
+      (tester) async {
+        const itemTitle = 'Test Item';
+        final layout = ListDetailLayout(
+          items: const [ListItem(title: Text(itemTitle))],
+          detailBuilder: (_, _) => const SizedBox(),
+          showEmptyHint: false,
+          listActionsBuilder: (_) => [
+            IconButton(
+              key: const Key('action_btn'),
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(_wrap(layout));
+
+        expect(find.text(itemTitle), findsOneWidget);
+        expect(find.byKey(const Key('action_btn')), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `listActionsBuilder` parameter to `ListDetailLayout` — an optional callback returning icon buttons rendered as a header row above the list pane
- When `null` (the default), no header row is rendered and all existing screens remain pixel-identical
- Widget tests cover both the null and non-null cases, plus an edge case where the builder returns `null`

Closes #168

## Test plan

- [ ] `flutter test test/widget/list_detail_layout_test.dart` — all 4 tests pass
- [ ] `dart analyze` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)