### PR TITLE
PDF export: full flow for all aktive Jugendliche with configurable fields

### DIFF
--- a/lib/ui/jugendliche/export_dialog.dart
+++ b/lib/ui/jugendliche/export_dialog.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:printing/printing.dart';
+
+import '../../repository/model/jugendliche/jugendlicher.dart';
+import 'pdf_export.dart';
+
+class _ExportField {
+  final String label;
+  final bool alwaysOn;
+  bool selected;
+
+  _ExportField({
+    required this.label,
+    required this.alwaysOn,
+    required this.selected,
+  });
+}
+
+class JugendlicheExportDialog extends StatefulWidget {
+  final List<Jugendlicher> jugendliche;
+
+  const JugendlicheExportDialog({super.key, required this.jugendliche});
+
+  @override
+  State<JugendlicheExportDialog> createState() =>
+      _JugendlicheExportDialogState();
+}
+
+class _JugendlicheExportDialogState extends State<JugendlicheExportDialog> {
+  final _titleController = TextEditingController();
+  late final List<_ExportField> _fields;
+
+  @override
+  void initState() {
+    super.initState();
+    _fields = [
+      _ExportField(label: 'Name', alwaysOn: true, selected: true),
+      _ExportField(label: 'Passnummer', alwaysOn: false, selected: true),
+      _ExportField(label: 'Geburtsdatum', alwaysOn: false, selected: true),
+      _ExportField(label: 'Geschlecht', alwaysOn: false, selected: false),
+      _ExportField(label: 'Mitglied seit', alwaysOn: false, selected: false),
+      _ExportField(label: 'Austrittsdatum', alwaysOn: false, selected: false),
+      _ExportField(label: 'Austrittsgrund', alwaysOn: false, selected: false),
+      _ExportField(label: 'Unterschrift', alwaysOn: false, selected: false),
+    ];
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _export() async {
+    final selectedFields = _fields
+        .where((f) => f.selected)
+        .map((f) => f.label)
+        .toList();
+    final pdfBytes = await generateJugendlichePdf(
+      title: _titleController.text,
+      exportDate: DateTime.now(),
+      jugendliche: widget.jugendliche,
+      selectedFields: selectedFields,
+    );
+
+    if (!mounted) return;
+    Navigator.of(context).pop();
+
+    await Printing.layoutPdf(
+      onLayout: (_) => Future.value(pdfBytes),
+      name: _titleController.text.isEmpty
+          ? 'Jugendliche'
+          : _titleController.text,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('PDF exportieren'),
+      content: SizedBox(
+        width: 400,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Titel',
+                  hintText: 'z.B. Zeltlager 2026',
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text('Felder auswählen:'),
+              const SizedBox(height: 8),
+              ..._fields.map(
+                (field) => CheckboxListTile(
+                  title: Text(field.label),
+                  value: field.selected,
+                  onChanged: field.alwaysOn
+                      ? null
+                      : (value) =>
+                            setState(() => field.selected = value ?? false),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  dense: true,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Abbrechen'),
+        ),
+        ElevatedButton(onPressed: _export, child: const Text('Exportieren')),
+      ],
+    );
+  }
+}

--- a/lib/ui/jugendliche/jugendliche_screen.dart
+++ b/lib/ui/jugendliche/jugendliche_screen.dart
@@ -6,6 +6,7 @@ import '../../router/router.dart';
 import '../../view_model/jugendlicher/jugendlicher_view.dart';
 import '../list_detail/list_detail.dart';
 import 'austritt_dialog.dart';
+import 'export_dialog.dart';
 import 'jugendliche_form.dart';
 
 class JugendlicheScreen extends ConsumerStatefulWidget {
@@ -55,6 +56,13 @@ class _JugendlicheScreenState extends ConsumerState<JugendlicheScreen> {
         if (index == -1) {
           index = null;
         }
+        final aktiveJugendliche =
+            allJugendliche
+                .where((j) => j.replacedBy == null && !j.isAusgetreten(today))
+                .toList()
+              ..sort(
+                (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+              );
         return ListDetailLayout(
           items: items,
           initialSelectedIndex: index,
@@ -63,6 +71,17 @@ class _JugendlicheScreenState extends ConsumerState<JugendlicheScreen> {
               'Wähle einen Jugendlichen aus der Liste aus, um Details zu sehen.',
             ),
           ),
+          listActionsBuilder: (context) => [
+            IconButton(
+              tooltip: 'PDF exportieren',
+              icon: const Icon(Icons.download),
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) =>
+                    JugendlicheExportDialog(jugendliche: aktiveJugendliche),
+              ),
+            ),
+          ],
           form: JugendlicherForm(
             onSave: (name, gender, birthDate, memberSince, pass) async {
               final id = await ref

--- a/lib/ui/jugendliche/pdf_export.dart
+++ b/lib/ui/jugendliche/pdf_export.dart
@@ -1,0 +1,97 @@
+import 'dart:typed_data';
+
+import 'package:intl/intl.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+import '../../repository/model/jugendliche/jugendlicher.dart';
+
+Future<Uint8List> generateJugendlichePdf({
+  required String title,
+  required DateTime exportDate,
+  required List<Jugendlicher> jugendliche,
+  required List<String> selectedFields,
+}) {
+  final doc = pw.Document();
+  final dateFormat = DateFormat.yMd('de');
+
+  final headers = selectedFields;
+  final rows = jugendliche
+      .map(
+        (j) => selectedFields
+            .map(
+              (field) => switch (field) {
+                'Name' => j.name,
+                'Passnummer' => j.pass ?? '',
+                'Geburtsdatum' => dateFormat.format(j.birthDate),
+                'Geschlecht' => j.gender.display,
+                'Mitglied seit' => dateFormat.format(j.memberSince),
+                'Austrittsdatum' =>
+                  j.exitDate != null ? dateFormat.format(j.exitDate!) : '',
+                'Austrittsgrund' => j.exitReason?.display ?? '',
+                'Unterschrift' => '',
+                _ => '',
+              },
+            )
+            .toList(),
+      )
+      .toList();
+
+  doc.addPage(
+    pw.MultiPage(
+      pageFormat: PdfPageFormat.a4,
+      header: (context) => pw.Column(
+        crossAxisAlignment: pw.CrossAxisAlignment.start,
+        children: [
+          if (title.isNotEmpty)
+            pw.Text(
+              title,
+              style: pw.TextStyle(fontSize: 18, fontWeight: pw.FontWeight.bold),
+            ),
+          pw.Text('Exportiert am: ${dateFormat.format(exportDate)}'),
+          pw.SizedBox(height: 8),
+        ],
+      ),
+      footer: (context) => pw.Row(
+        mainAxisAlignment: pw.MainAxisAlignment.end,
+        children: [
+          pw.Text('Seite ${context.pageNumber} von ${context.pagesCount}'),
+        ],
+      ),
+      build: (context) => [
+        pw.Table(
+          border: pw.TableBorder.all(),
+          children: [
+            pw.TableRow(
+              children: headers
+                  .map(
+                    (h) => pw.Padding(
+                      padding: const pw.EdgeInsets.all(4),
+                      child: pw.Text(
+                        h,
+                        style: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+            ...rows.map(
+              (row) => pw.TableRow(
+                children: row
+                    .map(
+                      (cell) => pw.Padding(
+                        padding: const pw.EdgeInsets.all(4),
+                        child: pw.Text(cell),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+
+  return doc.save();
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <printing/printing_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
@@ -16,4 +17,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) printing_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
+  printing_plugin_register_with_registrar(printing_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
+  printing
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,12 @@ import Foundation
 
 import file_selector_macos
 import flutter_secure_storage_darwin
+import printing
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
+  PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:
@@ -765,6 +781,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: e47a275b267873d5944ad5f5ff0dcc7ac2e36c02b3046a0ffac9b72fd362c44b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.12.0"
+  pdf_widget_wrapper:
+    dependency: transitive
+    description:
+      name: pdf_widget_wrapper
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -813,6 +845,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  printing:
+    dependency: "direct main"
+    description:
+      name: printing
+      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.3"
   pub_semver:
     dependency: transitive
     description:
@@ -837,6 +877,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   record_use:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   jlcrypto:
     path: ./packages/jlcrypto
   file_selector: ^1.1.0
+  pdf: ^3.12.0
+  printing: ^5.14.3
   freezed_annotation: ^3.1.0
   meta: ^1.17.0
   flutter_localizations:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <printing/printing_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  PrintingPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PrintingPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   flutter_secure_storage_windows
+  printing
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary

- Adds `pdf ^3.12.0` and `printing ^5.14.3` packages
- New `listActionsBuilder` download button in the Jugendliche list pane opens a modal export dialog
- Dialog has a custom title field and checkboxes for Name (always on), Passnummer (pre-checked), Geburtsdatum (pre-checked), Geschlecht, Mitglied seit, Austrittsdatum, Austrittsgrund, Unterschrift
- Exported set is always all aktive Jugendliche (`replacedBy == null && !isAusgetreten`)
- Generated PDF: title, export date, paginated A4 table with selected columns in fixed order, page numbers in footer
- `dart analyze` reports no warnings

## Test plan

- [x] Download icon appears in the Jugendliche list pane (not the detail pane)
- [x] Dialog shows title field and all eight field checkboxes with correct defaults
- [x] Cancelling closes dialog without generating a PDF
- [x] Confirming opens OS print/save dialog
- [x] Resulting PDF contains title, export date, table with only the selected columns, page numbers
- [x] Only aktive Jugendliche appear in the PDF (no ausgetretene, no ersetzte)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)