### PR TITLE
Add undefinierteJugendlicherIds to EintragApiModel (jldb)

### DIFF
--- a/lib/repository/eintrag/eintrag_repo.dart
+++ b/lib/repository/eintrag/eintrag_repo.dart
@@ -66,6 +66,7 @@ class EintragRepository
             entschuldigteJugendlicherIds: data.entschuldigteJugendlicherIds
                 .map(UUID.fromString)
                 .toSet(),
+            undefinierteJugendlicherIds: const {},
           ),
         )
         .map((savedRecord) {

--- a/lib/view_model/dashboard/dashboard_viewmodel.dart
+++ b/lib/view_model/dashboard/dashboard_viewmodel.dart
@@ -166,6 +166,7 @@ class DashboardViewModel {
         entschuldigteJugendlicherIds: e.entschuldigteJugendlicherIds
             .map(UUID.fromString)
             .toSet(),
+        undefinierteJugendlicherIds: const {},
       );
     }).toList();
 

--- a/packages/jldb/lib/src/models/eintrag/eintrag_api_model.dart
+++ b/packages/jldb/lib/src/models/eintrag/eintrag_api_model.dart
@@ -22,6 +22,7 @@ abstract class EintragApiModel with _$EintragApiModel {
     required Set<UUID> betreuerIds,
     required Set<UUID> anwesendeJugendlicherIds,
     required Set<UUID> entschuldigteJugendlicherIds,
+    required Set<UUID> undefinierteJugendlicherIds,
   }) = _EintragApiModel;
 }
 
@@ -54,6 +55,7 @@ EintragApiModel eintragApiModelFromDbArray(
 
   final anwesendeJugendlicherIds = <UUID>{};
   final entschuldigteJugendlicherIds = <UUID>{};
+  final undefinierteJugendlicherIds = <UUID>{};
 
   final statusJugendlicherIds =
       (data[statusJugendlicherIdsIndex] as String?)
@@ -72,6 +74,8 @@ EintragApiModel eintragApiModelFromDbArray(
       anwesendeJugendlicherIds.add(jugendlicherId);
     } else if (status == eintragStatusEntschuldigt) {
       entschuldigteJugendlicherIds.add(jugendlicherId);
+    } else {
+      undefinierteJugendlicherIds.add(jugendlicherId);
     }
   }
 
@@ -98,5 +102,6 @@ EintragApiModel eintragApiModelFromDbArray(
         {},
     anwesendeJugendlicherIds: anwesendeJugendlicherIds,
     entschuldigteJugendlicherIds: entschuldigteJugendlicherIds,
+    undefinierteJugendlicherIds: undefinierteJugendlicherIds,
   );
 }

--- a/packages/jldb/test/attendance_rate_calculator_test.dart
+++ b/packages/jldb/test/attendance_rate_calculator_test.dart
@@ -18,6 +18,7 @@ EintragApiModel _makeEintrag({
   betreuerIds: const {},
   anwesendeJugendlicherIds: anwesend ?? const {},
   entschuldigteJugendlicherIds: entschuldigt ?? const {},
+  undefinierteJugendlicherIds: const {},
 );
 
 JugendlicherApiModel _makeJugendlicher({

--- a/packages/jldb/test/jldb_test.dart
+++ b/packages/jldb/test/jldb_test.dart
@@ -50,6 +50,7 @@ Future<EintragApiModel> _createSignableEintrag(Jldb db) async {
           betreuerIds: {betreuer.id},
           anwesendeJugendlicherIds: {jugId},
           entschuldigteJugendlicherIds: const {},
+          undefinierteJugendlicherIds: const {},
         ),
       )
       .unwrap();
@@ -191,6 +192,7 @@ void main() {
                 betreuerIds: const {},
                 anwesendeJugendlicherIds: {jugId},
                 entschuldigteJugendlicherIds: const {},
+                undefinierteJugendlicherIds: const {},
               ),
             )
             .unwrap();
@@ -402,6 +404,7 @@ void main() {
       betreuerIds: {betreuerId},
       anwesendeJugendlicherIds: {jugAnwesendId},
       entschuldigteJugendlicherIds: {jugEntschuldigtId},
+      undefinierteJugendlicherIds: const {},
     );
 
     test('createEintrag round-trips the full model', () async {
@@ -475,6 +478,7 @@ void main() {
           betreuerIds: const {},
           anwesendeJugendlicherIds: const {},
           entschuldigteJugendlicherIds: const {},
+          undefinierteJugendlicherIds: const {},
         );
         final created = await db.createEintrag(eintrag).unwrap();
         expect(created.betreuerIds, isEmpty);
@@ -823,6 +827,7 @@ void main() {
               betreuerIds: const {},
               anwesendeJugendlicherIds: {jugId},
               entschuldigteJugendlicherIds: const {},
+              undefinierteJugendlicherIds: const {},
             ),
           )
           .unwrap();

--- a/packages/jldb/test/models/eintrag_model_test.dart
+++ b/packages/jldb/test/models/eintrag_model_test.dart
@@ -35,20 +35,19 @@ void main() {
       String? raum,
       String? dienstverlauf,
       String? besonderheiten,
-    }) =>
-        [
-          eintragId,
-          startMs,
-          endMs,
-          kategorieId,
-          'Sportabend',
-          ort,
-          raum,
-          dienstverlauf,
-          besonderheiten,
-          jugendliche,
-          betreuer,
-        ];
+    }) => [
+      eintragId,
+      startMs,
+      endMs,
+      kategorieId,
+      'Sportabend',
+      ort,
+      raum,
+      dienstverlauf,
+      besonderheiten,
+      jugendliche,
+      betreuer,
+    ];
 
     test('parses minimal row with no jugendliche and no betreuer', () {
       final model = eintragApiModelFromDbArray(makeRow(), fullColumns);
@@ -56,14 +55,12 @@ void main() {
       expect(model.id, equals(UUID.fromString(eintragId)));
       expect(model.kategorieId, equals(UUID.fromString(kategorieId)));
       expect(model.thema, equals('Sportabend'));
-      expect(
-        model.start,
-        equals(DateTime.fromMillisecondsSinceEpoch(startMs)),
-      );
+      expect(model.start, equals(DateTime.fromMillisecondsSinceEpoch(startMs)));
       expect(model.end, equals(DateTime.fromMillisecondsSinceEpoch(endMs)));
       expect(model.betreuerIds, isEmpty);
       expect(model.anwesendeJugendlicherIds, isEmpty);
       expect(model.entschuldigteJugendlicherIds, isEmpty);
+      expect(model.undefinierteJugendlicherIds, isEmpty);
       expect(model.ort, isNull);
       expect(model.raum, isNull);
       expect(model.dienstverlauf, isNull);
@@ -88,19 +85,20 @@ void main() {
     });
 
     test('classifies status 1 as anwesend', () {
-      final model =
-          eintragApiModelFromDbArray(makeRow(jugendliche: '$jugId1:1'), fullColumns);
-
-      expect(
-        model.anwesendeJugendlicherIds,
-        contains(UUID.fromString(jugId1)),
+      final model = eintragApiModelFromDbArray(
+        makeRow(jugendliche: '$jugId1:1'),
+        fullColumns,
       );
+
+      expect(model.anwesendeJugendlicherIds, contains(UUID.fromString(jugId1)));
       expect(model.entschuldigteJugendlicherIds, isEmpty);
     });
 
     test('classifies status 2 as entschuldigt', () {
-      final model =
-          eintragApiModelFromDbArray(makeRow(jugendliche: '$jugId1:2'), fullColumns);
+      final model = eintragApiModelFromDbArray(
+        makeRow(jugendliche: '$jugId1:2'),
+        fullColumns,
+      );
 
       expect(
         model.entschuldigteJugendlicherIds,
@@ -115,10 +113,7 @@ void main() {
         fullColumns,
       );
 
-      expect(
-        model.anwesendeJugendlicherIds,
-        contains(UUID.fromString(jugId1)),
-      );
+      expect(model.anwesendeJugendlicherIds, contains(UUID.fromString(jugId1)));
       expect(
         model.entschuldigteJugendlicherIds,
         contains(UUID.fromString(jugId2)),
@@ -128,8 +123,10 @@ void main() {
     });
 
     test('parses a single betreuer id', () {
-      final model =
-          eintragApiModelFromDbArray(makeRow(betreuer: betreuerId), fullColumns);
+      final model = eintragApiModelFromDbArray(
+        makeRow(betreuer: betreuerId),
+        fullColumns,
+      );
 
       expect(model.betreuerIds, contains(UUID.fromString(betreuerId)));
     });
@@ -145,15 +142,18 @@ void main() {
       expect(model.betreuerIds, contains(UUID.fromString(jugId1)));
     });
 
-    test('throws FormatException for a malformed jugendlicher status entry', () {
-      expect(
-        () => eintragApiModelFromDbArray(
-          makeRow(jugendliche: 'no-colon-here'),
-          fullColumns,
-        ),
-        throwsFormatException,
-      );
-    });
+    test(
+      'throws FormatException for a malformed jugendlicher status entry',
+      () {
+        expect(
+          () => eintragApiModelFromDbArray(
+            makeRow(jugendliche: 'no-colon-here'),
+            fullColumns,
+          ),
+          throwsFormatException,
+        );
+      },
+    );
 
     test('works without optional columns returning null for absent fields', () {
       const minColumns = [
@@ -165,7 +165,15 @@ void main() {
         'status_jugendlicher_ids',
         'betreuer_ids',
       ];
-      final minRow = [eintragId, startMs, endMs, kategorieId, 'Test', null, null];
+      final minRow = [
+        eintragId,
+        startMs,
+        endMs,
+        kategorieId,
+        'Test',
+        null,
+        null,
+      ];
       final model = eintragApiModelFromDbArray(minRow, minColumns);
 
       expect(model.ort, isNull);
@@ -186,6 +194,52 @@ void main() {
       expect(
         () => eintragApiModelFromDbArray([], noId),
         throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('classifies status 0 as undefiniert', () {
+      final model = eintragApiModelFromDbArray(
+        makeRow(jugendliche: '$jugId1:0'),
+        fullColumns,
+      );
+
+      expect(
+        model.undefinierteJugendlicherIds,
+        contains(UUID.fromString(jugId1)),
+      );
+      expect(model.anwesendeJugendlicherIds, isEmpty);
+      expect(model.entschuldigteJugendlicherIds, isEmpty);
+    });
+
+    test('classifies unknown status (99) as undefiniert', () {
+      final model = eintragApiModelFromDbArray(
+        makeRow(jugendliche: '$jugId1:99'),
+        fullColumns,
+      );
+
+      expect(
+        model.undefinierteJugendlicherIds,
+        contains(UUID.fromString(jugId1)),
+      );
+      expect(model.anwesendeJugendlicherIds, isEmpty);
+      expect(model.entschuldigteJugendlicherIds, isEmpty);
+    });
+
+    test('splits mixed attendance correctly across all three groups', () {
+      const jugId3 = '550e8400-e29b-41d4-a716-446655440006';
+      final model = eintragApiModelFromDbArray(
+        makeRow(jugendliche: '$jugId1:1,$jugId2:2,$jugId3:0'),
+        fullColumns,
+      );
+
+      expect(model.anwesendeJugendlicherIds, equals({UUID.fromString(jugId1)}));
+      expect(
+        model.entschuldigteJugendlicherIds,
+        equals({UUID.fromString(jugId2)}),
+      );
+      expect(
+        model.undefinierteJugendlicherIds,
+        equals({UUID.fromString(jugId3)}),
       );
     });
   });


### PR DESCRIPTION
Closes #175

## Summary

- Added `undefinierteJugendlicherIds: Set<UUID>` as a required field to `EintragApiModel`
- Updated `eintragApiModelFromDbArray` to place IDs with status `0` or any unknown status into the new set (previously silently dropped)
- Updated all direct `EintragApiModel` constructions in the app layer (`eintrag_repo.dart`, `dashboard_viewmodel.dart`) to pass `undefinierteJugendlicherIds: const {}` until #176 mirrors the field in the domain model
- Updated all existing tests that construct `EintragApiModel` directly (`jldb_test.dart`, `attendance_rate_calculator_test.dart`)
- Added 3 new tests in `eintrag_model_test.dart`: status 0 → undefiniert, status 99 → undefiniert, mixed all-three-groups split correctly

## Test plan

- [x] All 13 `eintrag_model_test.dart` tests pass (including 3 new ones)
- [x] All 123 jldb package tests pass
- [x] `dart analyze` reports no issues in jldb or the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)