### PR TITLE
Add LogFileHandler + Riverpod provider for app-wide logging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'ui/app.dart';
+import 'provider/logging/logging.dart';
 import 'provider/shared_pref/shared_pref.dart';
+import 'ui/app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await createSharedPreferences();
+  final logPath = await initLoggingService();
   runApp(
     ProviderScope(
-      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        loggingServiceProvider.overrideWithValue(logPath),
+      ],
       child: const JulogApp(),
     ),
   );

--- a/lib/provider/logging/logging.dart
+++ b/lib/provider/logging/logging.dart
@@ -1,0 +1,17 @@
+import 'package:path_provider/path_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../service/log_file_handler.dart';
+
+part 'logging.g.dart';
+
+@Riverpod(keepAlive: true)
+String loggingService(Ref ref) => throw UnimplementedError();
+
+Future<String> initLoggingService() async {
+  final dir = await getApplicationSupportDirectory();
+  final filePath = '${dir.path}/julog.log';
+  final handler = LogFileHandler(filePath: filePath);
+  handler.listen();
+  return filePath;
+}

--- a/lib/service/log_file_handler.dart
+++ b/lib/service/log_file_handler.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+class LogFileHandler {
+  final String filePath;
+  final int _maxEntries;
+  final _buffer = <LogRecord>[];
+
+  LogFileHandler({required this.filePath, int maxEntries = 100})
+    : _maxEntries = maxEntries;
+
+  void listen() {
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen(_onRecord);
+  }
+
+  void addRecord(LogRecord record) => _onRecord(record);
+
+  void _onRecord(LogRecord record) {
+    if (_buffer.length >= _maxEntries) {
+      _buffer.removeAt(0);
+    }
+    _buffer.add(record);
+    _flush();
+  }
+
+  void _flush() {
+    final content = _buffer.map(_formatRecord).join('\n');
+    File(filePath).writeAsStringSync('$content\n');
+  }
+
+  String _formatRecord(LogRecord r) {
+    final sb = StringBuffer()
+      ..write(r.time.toIso8601String())
+      ..write(' ')
+      ..write(r.level.name)
+      ..write(' ')
+      ..write(r.loggerName)
+      ..write(': ')
+      ..write(r.message);
+    if (r.stackTrace != null) {
+      sb
+        ..write('\n')
+        ..write(r.stackTrace);
+    }
+    return sb.toString();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -630,7 +630,7 @@ packages:
     source: hosted
     version: "6.1.0"
   logging:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
@@ -734,7 +734,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dependencies:
     sdk: flutter
   intl: any
   flutter_secure_storage: ^10.0.0
+  logging: ^1.2.0
+  path_provider: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/service/log_file_handler_test.dart
+++ b/test/service/log_file_handler_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+
+import 'package:julog/service/log_file_handler.dart';
+
+void main() {
+  group('LogFileHandler', () {
+    late Directory tempDir;
+    late String filePath;
+    late LogFileHandler handler;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('log_file_handler_test_');
+      filePath = '${tempDir.path}/test.log';
+      handler = LogFileHandler(filePath: filePath, maxEntries: 100);
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    LogRecord makeRecord(String message) =>
+        LogRecord(Level.INFO, message, 'test');
+
+    test('writes file after first log entry', () {
+      handler.addRecord(makeRecord('first'));
+
+      expect(File(filePath).existsSync(), isTrue);
+      final content = File(filePath).readAsStringSync();
+      expect(content, contains('first'));
+    });
+
+    test('contains all entries up to maxEntries', () {
+      for (var i = 0; i < 100; i++) {
+        handler.addRecord(makeRecord('msg-$i'));
+      }
+
+      final lines = File(
+        filePath,
+      ).readAsStringSync().split('\n').where((l) => l.isNotEmpty).toList();
+      expect(lines, hasLength(100));
+      expect(lines.last, contains('msg-99'));
+    });
+
+    test('rolling buffer: after 101 entries only 100 remain', () {
+      for (var i = 0; i < 101; i++) {
+        handler.addRecord(makeRecord('msg-$i'));
+      }
+
+      final lines = File(
+        filePath,
+      ).readAsStringSync().split('\n').where((l) => l.isNotEmpty).toList();
+      expect(lines, hasLength(100));
+      expect(lines.first, contains('msg-1'));
+      expect(lines.last, contains('msg-100'));
+    });
+
+    test('oldest entry is dropped when buffer overflows', () {
+      for (var i = 0; i < 105; i++) {
+        handler.addRecord(makeRecord('entry-$i'));
+      }
+
+      final lines = File(
+        filePath,
+      ).readAsStringSync().split('\n').where((l) => l.isNotEmpty).toList();
+      // Buffer holds entry-5..entry-104; entry-0..entry-4 are evicted.
+      expect(lines.first, endsWith(': entry-5'));
+      expect(lines.last, endsWith(': entry-104'));
+      expect(lines.any((l) => l.endsWith(': entry-0')), isFalse);
+      expect(lines.any((l) => l.endsWith(': entry-4')), isFalse);
+    });
+
+    test('log record includes timestamp, level, logger name, and message', () {
+      handler.addRecord(makeRecord('hello world'));
+
+      final content = File(filePath).readAsStringSync();
+      expect(content, contains('INFO'));
+      expect(content, contains('test'));
+      expect(content, contains('hello world'));
+    });
+
+    test('log record with stack trace includes stack trace', () {
+      final record = LogRecord(
+        Level.SEVERE,
+        'boom',
+        'test',
+        null,
+        StackTrace.current,
+      );
+      handler.addRecord(record);
+
+      final content = File(filePath).readAsStringSync();
+      expect(content, contains('boom'));
+      expect(content, contains('#0'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #181

## Summary

- Adds `logging` (dart.dev) and `path_provider` as explicit dependencies in `pubspec.yaml`
- Implements `LogFileHandler`: listens on `Logger.root.onRecord`, maintains a rolling 100-entry buffer, rewrites the log file on every new record under `getApplicationSupportDirectory()`
- Adds `loggingServiceProvider` (keepAlive Riverpod provider) pre-initialised in `main()` before `runApp()`, exposing the log file path as a `String`
- Unit tests cover: file creation on first record, full buffer, rolling eviction at 101 entries, format (timestamp/level/logger/message), stack trace inclusion

## Test plan

- [x] `flutter test test/service/log_file_handler_test.dart` — 6/6 pass
- [x] `dart analyze` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)