### PR TITLE
Add CorruptedKeyContainerException to jlcrypto

### DIFF
--- a/lib/repository/identity/exception.dart
+++ b/lib/repository/identity/exception.dart
@@ -1,6 +1,1 @@
 class PrivateKeyNotFoundException implements Exception {}
-
-class PasswortWrongException implements Exception {
-  @override
-  String toString() => 'Passwort falsch';
-}

--- a/lib/repository/identity/repository.dart
+++ b/lib/repository/identity/repository.dart
@@ -51,15 +51,16 @@ class IdentityRepository
         final crypto.PrivateKey privateKey;
         try {
           privateKey = await compute(
-                (message) =>
-                crypto.PrivateKey.fromString(
-                  message.privateKeyString,
-                  message.password,
-                ),
+            (message) => crypto.PrivateKey.fromString(
+              message.privateKeyString,
+              message.password,
+            ),
             (privateKeyString: privateKeyString, password: password),
           );
-        } catch(e) {
-          throw PasswortWrongException();
+        } on crypto.CorruptedKeyContainerException {
+          rethrow;
+        } on Exception {
+          throw crypto.PasswortWrongException();
         }
 
         return OpenIdentity(id: id, privateKey: privateKey);

--- a/packages/jlcrypto/lib/jlcrypto.dart
+++ b/packages/jlcrypto/lib/jlcrypto.dart
@@ -3,6 +3,7 @@
 /// More dartdocs go here.
 library;
 
+export 'src/exceptions.dart';
 export 'src/public_key.dart' hide createPublicKeyFromRsaKey;
 export 'src/private_key.dart' hide createPrivateKeyFromRsaKey, encodePrivateKey;
 export 'src/keypair.dart';

--- a/packages/jlcrypto/lib/src/exceptions.dart
+++ b/packages/jlcrypto/lib/src/exceptions.dart
@@ -1,0 +1,6 @@
+class CorruptedKeyContainerException implements Exception {}
+
+class PasswortWrongException implements Exception {
+  @override
+  String toString() => 'Passwort falsch';
+}

--- a/packages/jlcrypto/lib/src/private_key.dart
+++ b/packages/jlcrypto/lib/src/private_key.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:pointycastle/export.dart' as pc;
 
+import 'exceptions.dart';
 import 'identity.dart';
 import 'public_key.dart';
 import 'signature.dart';
@@ -46,20 +47,29 @@ class PrivateKey {
   PrivateKey._(this._rsaPrivateKey, this._publicKey, this._encodedPrivateKey);
 
   PrivateKey.fromString(String privateKeyString, String password) {
-    final json =
-        jsonDecode(utf8.decode(base64Decode(privateKeyString)))
-            as Map<String, dynamic>;
-    _encodedPrivateKey = json['private'] as String;
-    _publicKey = PublicKey.fromString(json['public'] as String);
-    final decrypted =
-        jsonDecode(decrypt(_encodedPrivateKey, password))
-            as Map<String, dynamic>;
-    _rsaPrivateKey = pc.RSAPrivateKey(
-      BigInt.parse(decrypted['modulus'] as String),
-      BigInt.parse(decrypted['privateExponent'] as String),
-      BigInt.parse(decrypted['p'] as String),
-      BigInt.parse(decrypted['q'] as String),
-    );
+    final Map<String, dynamic> json;
+    try {
+      json =
+          jsonDecode(utf8.decode(base64Decode(privateKeyString)))
+              as Map<String, dynamic>;
+      _encodedPrivateKey = json['private'] as String;
+      _publicKey = PublicKey.fromString(json['public'] as String);
+    } catch (_) {
+      throw CorruptedKeyContainerException();
+    }
+    try {
+      final decrypted =
+          jsonDecode(decrypt(_encodedPrivateKey, password))
+              as Map<String, dynamic>;
+      _rsaPrivateKey = pc.RSAPrivateKey(
+        BigInt.parse(decrypted['modulus'] as String),
+        BigInt.parse(decrypted['privateExponent'] as String),
+        BigInt.parse(decrypted['p'] as String),
+        BigInt.parse(decrypted['q'] as String),
+      );
+    } catch (_) {
+      throw PasswortWrongException();
+    }
   }
 
   Signature signSHA512(Message message) => _sign(message, 'SHA-512/RSA');

--- a/packages/jlcrypto/test/jlcrypt_test.dart
+++ b/packages/jlcrypto/test/jlcrypt_test.dart
@@ -55,4 +55,52 @@ void main() {
       expect(loadedPrivate, isNotNull);
     });
   });
+
+  group('PrivateKey.fromString exception behaviour', () {
+    late String validEncoded;
+
+    setUpAll(() {
+      final kp = KeyPair.generate(
+        identity: KeyOwner('Test', 'Tester', 'test@example.com'),
+        password: 'correct-password',
+      );
+      validEncoded = kp.privateKey.toString();
+    });
+
+    test('correct key and password — no exception', () {
+      expect(
+        () => PrivateKey.fromString(validEncoded, 'correct-password'),
+        returnsNormally,
+      );
+    });
+
+    test('wrong password — throws PasswortWrongException', () {
+      expect(
+        () => PrivateKey.fromString(validEncoded, 'wrong-password'),
+        throwsA(isA<PasswortWrongException>()),
+      );
+    });
+
+    test(
+      'corrupted outer container (invalid base64) — throws CorruptedKeyContainerException',
+      () {
+        expect(
+          () => PrivateKey.fromString('not-valid-base64!!!', 'any-password'),
+          throwsA(isA<CorruptedKeyContainerException>()),
+        );
+      },
+    );
+
+    test(
+      'corrupted outer container (valid base64, invalid JSON) — throws CorruptedKeyContainerException',
+      () {
+        // base64-encode a string that is not valid JSON
+        const encoded = 'dGhpcyBpcyBub3QganNvbg=='; // "this is not json"
+        expect(
+          () => PrivateKey.fromString(encoded, 'any-password'),
+          throwsA(isA<CorruptedKeyContainerException>()),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- Adds `CorruptedKeyContainerException` and moves `PasswortWrongException` into `jlcrypto/src/exceptions.dart`, exported from the package
- `PrivateKey.fromString()` now throws `CorruptedKeyContainerException` when base64 decoding or outer JSON parsing fails, and `PasswortWrongException` when AES decryption or inner JSON parsing fails
- `IdentityRepository.openIdentity()` lets `CorruptedKeyContainerException` propagate unchanged; other exceptions become `crypto.PasswortWrongException`
- Extends `jlcrypt_test.dart` with three cases: correct key+password, wrong password, corrupted outer container

Closes #180

## Test plan

- [x] `dart test packages/jlcrypto/test/jlcrypt_test.dart` — all 6 tests pass
- [x] `dart analyze` on changed files — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)