### PR TITLE
Mirror undefinierteJugendliche in Eintrag domain model and SelectedEintrag

### DIFF
--- a/lib/assembly/eintrag_assembly.dart
+++ b/lib/assembly/eintrag_assembly.dart
@@ -16,31 +16,54 @@ part 'eintrag_assembly.g.dart';
 part 'eintrag_assembly.freezed.dart';
 
 class EintragAssembly {
-  final JulogRepository<Eintrag, EintragApiModel, EintragCreateData> _eintragRepo;
-  final JulogRepository<Kategorie, KategorieApiModel, KategorieCreate> _kategorieRepo;
-  final JulogRepository<Jugendlicher, JugendlicherApiModel, JugendlicheCreateData>
-      _jugendlicheRepo;
-  final JulogRepository<Betreuer, BetreuerApiModel, ({String name, Gender gender})>
-      _betreuerRepo;
-  final JulogRepository<Identity, IdentityApiModel, IdentityCreateData> _identityRepo;
+  final JulogRepository<Eintrag, EintragApiModel, EintragCreateData>
+  _eintragRepo;
+  final JulogRepository<Kategorie, KategorieApiModel, KategorieCreate>
+  _kategorieRepo;
+  final JulogRepository<
+    Jugendlicher,
+    JugendlicherApiModel,
+    JugendlicheCreateData
+  >
+  _jugendlicheRepo;
+  final JulogRepository<
+    Betreuer,
+    BetreuerApiModel,
+    ({String name, Gender gender})
+  >
+  _betreuerRepo;
+  final JulogRepository<Identity, IdentityApiModel, IdentityCreateData>
+  _identityRepo;
 
   const EintragAssembly({
-    required JulogRepository<Eintrag, EintragApiModel, EintragCreateData> eintragRepo,
-    required JulogRepository<Kategorie, KategorieApiModel, KategorieCreate> kategorieRepo,
-    required JulogRepository<Jugendlicher, JugendlicherApiModel, JugendlicheCreateData>
-        jugendlicheRepo,
-    required JulogRepository<Betreuer, BetreuerApiModel, ({String name, Gender gender})>
-        betreuerRepo,
-    required JulogRepository<Identity, IdentityApiModel, IdentityCreateData> identityRepo,
-  })  : _eintragRepo = eintragRepo,
-        _kategorieRepo = kategorieRepo,
-        _jugendlicheRepo = jugendlicheRepo,
-        _betreuerRepo = betreuerRepo,
-        _identityRepo = identityRepo;
+    required JulogRepository<Eintrag, EintragApiModel, EintragCreateData>
+    eintragRepo,
+    required JulogRepository<Kategorie, KategorieApiModel, KategorieCreate>
+    kategorieRepo,
+    required JulogRepository<
+      Jugendlicher,
+      JugendlicherApiModel,
+      JugendlicheCreateData
+    >
+    jugendlicheRepo,
+    required JulogRepository<
+      Betreuer,
+      BetreuerApiModel,
+      ({String name, Gender gender})
+    >
+    betreuerRepo,
+    required JulogRepository<Identity, IdentityApiModel, IdentityCreateData>
+    identityRepo,
+  }) : _eintragRepo = eintragRepo,
+       _kategorieRepo = kategorieRepo,
+       _jugendlicheRepo = jugendlicheRepo,
+       _betreuerRepo = betreuerRepo,
+       _identityRepo = identityRepo;
 
   AsyncResult<SelectedEintrag> assemble(
     String eintragId,
-    JulogRepository<Signature, SignatureApiModel, SignatureCreateData> signatureRepo,
+    JulogRepository<Signature, SignatureApiModel, SignatureCreateData>
+    signatureRepo,
   ) {
     return Result.safeAsync(() async {
       final eintragOpt = await _eintragRepo.getById(eintragId).unwrap();
@@ -49,8 +72,9 @@ class EintragAssembly {
       }
       final eintrag = eintragOpt.unwrap();
 
-      final kategorieOpt =
-          await _kategorieRepo.getById(eintrag.kategorieId).unwrap();
+      final kategorieOpt = await _kategorieRepo
+          .getById(eintrag.kategorieId)
+          .unwrap();
       if (kategorieOpt is None<Kategorie>) {
         throw Exception('Kategorie not found: ${eintrag.kategorieId}');
       }
@@ -59,8 +83,9 @@ class EintragAssembly {
       final signatures = await signatureRepo
           .getAll()
           .mapIterable((signature) async {
-            final identity =
-                await _identityRepo.getById(signature.identityId).unwrapAll();
+            final identity = await _identityRepo
+                .getById(signature.identityId)
+                .unwrapAll();
             return ShowingSignature.fromSignature(
               signature: signature,
               identity: identity,
@@ -83,12 +108,18 @@ class EintragAssembly {
         return opt.unwrap();
       }
 
-      final betreuerList =
-          await Future.wait(eintrag.betreuerIds.map(resolveBetreuer));
+      final betreuerList = await Future.wait(
+        eintrag.betreuerIds.map(resolveBetreuer),
+      );
       final anwesendeJugendlicheList = await Future.wait(
-          eintrag.anwesendeJugendlicherIds.map(resolveJugendlicher));
+        eintrag.anwesendeJugendlicherIds.map(resolveJugendlicher),
+      );
       final entschuldigteJugendlicheList = await Future.wait(
-          eintrag.entschuldigteJugendlicherIds.map(resolveJugendlicher));
+        eintrag.entschuldigteJugendlicherIds.map(resolveJugendlicher),
+      );
+      final undefinierteJugendlicheList = await Future.wait(
+        eintrag.undefinierteJugendlicherIds.map(resolveJugendlicher),
+      );
 
       final possibleSigners = await _identityRepo.getAll().unwrap();
 
@@ -105,6 +136,7 @@ class EintragAssembly {
         betreuer: betreuerList,
         anwesendeJugendliche: anwesendeJugendlicheList,
         entschuldigteJugendliche: entschuldigteJugendlicheList,
+        undefinierteJugendliche: undefinierteJugendlicheList,
         signatures: signatures,
         possibleSigners: possibleSigners,
       );
@@ -138,6 +170,7 @@ abstract class SelectedEintrag with _$SelectedEintrag {
     required List<Betreuer> betreuer,
     required List<Jugendlicher> anwesendeJugendliche,
     required List<Jugendlicher> entschuldigteJugendliche,
+    required List<Jugendlicher> undefinierteJugendliche,
     required List<ShowingSignature> signatures,
     required List<Identity> possibleSigners,
   }) = _SelectedEintrag;
@@ -159,11 +192,11 @@ abstract class ShowingSignature with _$ShowingSignature {
     required Signature signature,
     required Identity identity,
   }) => ShowingSignature(
-        eintragId: signature.eintragId,
-        id: signature.id,
-        identity: identity,
-        signature: signature.signature,
-        timestamp: signature.timestamp,
-        isValid: signature.isValid,
-      );
+    eintragId: signature.eintragId,
+    id: signature.id,
+    identity: identity,
+    signature: signature.signature,
+    timestamp: signature.timestamp,
+    isValid: signature.isValid,
+  );
 }

--- a/lib/repository/model/eintrag/eintrag_model.dart
+++ b/lib/repository/model/eintrag/eintrag_model.dart
@@ -18,6 +18,7 @@ abstract class Eintrag with _$Eintrag {
     required Set<String> betreuerIds,
     required Set<String> anwesendeJugendlicherIds,
     required Set<String> entschuldigteJugendlicherIds,
+    required Set<String> undefinierteJugendlicherIds,
   }) = _Eintrag;
 
   static Eintrag fromApiModel(EintragApiModel model) {
@@ -36,6 +37,9 @@ abstract class Eintrag with _$Eintrag {
           .map((e) => e.toString())
           .toSet(),
       entschuldigteJugendlicherIds: model.entschuldigteJugendlicherIds
+          .map((e) => e.toString())
+          .toSet(),
+      undefinierteJugendlicherIds: model.undefinierteJugendlicherIds
           .map((e) => e.toString())
           .toSet(),
     );

--- a/test/assembly/eintrag_assembly_test.dart
+++ b/test/assembly/eintrag_assembly_test.dart
@@ -25,9 +25,11 @@ class _Stub<M extends Object, A extends Object, S extends Object>
   _Stub(this._items, this._idOf);
 
   @override
-  AsyncResult<Optional<M>> getById(String id) async =>
-      Success(Optional.fromNullable(
-          _items.where((item) => _idOf(item) == id).firstOrNull));
+  AsyncResult<Optional<M>> getById(String id) async => Success(
+    Optional.fromNullable(
+      _items.where((item) => _idOf(item) == id).firstOrNull,
+    ),
+  );
 
   @override
   AsyncResult<List<M>> getAll() async => Success(List.of(_items));
@@ -55,13 +57,13 @@ Identity _identity(String id) =>
     ClosedIdentity(id: id, publicKey: _testPublicKey, isLocal: false);
 
 Signature _sig(String eintragId, String identityId) => Signature(
-      eintragId: eintragId,
-      identityId: identityId,
-      signature: crypto.Signature(Uint8List.fromList([1, 2, 3])),
-      timestamp: DateTime(2024),
-      version: 4,
-      isValid: true,
-    );
+  eintragId: eintragId,
+  identityId: identityId,
+  signature: crypto.Signature(Uint8List.fromList([1, 2, 3])),
+  timestamp: DateTime(2024),
+  version: 4,
+  isValid: true,
+);
 
 Eintrag _eintrag({
   String id = 'e1',
@@ -69,17 +71,18 @@ Eintrag _eintrag({
   Set<String> betreuerIds = const {},
   Set<String> anwesendeIds = const {},
   Set<String> entschuldigteIds = const {},
-}) =>
-    Eintrag(
-      id: id,
-      start: DateTime(2024, 3, 1, 10),
-      end: DateTime(2024, 3, 1, 12),
-      kategorieId: kategorieId,
-      thema: 'Erste Hilfe',
-      betreuerIds: betreuerIds,
-      anwesendeJugendlicherIds: anwesendeIds,
-      entschuldigteJugendlicherIds: entschuldigteIds,
-    );
+  Set<String> undefinierteIds = const {},
+}) => Eintrag(
+  id: id,
+  start: DateTime(2024, 3, 1, 10),
+  end: DateTime(2024, 3, 1, 12),
+  kategorieId: kategorieId,
+  thema: 'Erste Hilfe',
+  betreuerIds: betreuerIds,
+  anwesendeJugendlicherIds: anwesendeIds,
+  entschuldigteJugendlicherIds: entschuldigteIds,
+  undefinierteJugendlicherIds: undefinierteIds,
+);
 
 Kategorie _kategorie(String id) => Kategorie(id: id, name: 'Test Kategorie');
 
@@ -87,13 +90,13 @@ Betreuer _betreuer(String id) =>
     Betreuer(id: id, name: 'Betreuer $id', gender: Gender.male);
 
 Jugendlicher _jugendlicher(String id) => Jugendlicher(
-      id: id,
-      name: 'Jugendlicher $id',
-      gender: Gender.male,
-      birthDate: DateTime(2005),
-      memberSince: DateTime(2020),
-      eintragIds: {},
-    );
+  id: id,
+  name: 'Jugendlicher $id',
+  gender: Gender.male,
+  birthDate: DateTime(2005),
+  memberSince: DateTime(2020),
+  eintragIds: {},
+);
 
 // ---------------------------------------------------------------------------
 // Assembly factory — each list becomes a _Stub for its repo
@@ -105,33 +108,45 @@ EintragAssembly _assembly({
   List<Jugendlicher> jugendliche = const [],
   List<Betreuer> betreuer = const [],
   List<Identity> identities = const [],
-}) =>
-    EintragAssembly(
-      eintragRepo: _Stub<Eintrag, EintragApiModel, EintragCreateData>(
-          eintraege, (e) => e.id),
-      kategorieRepo: _Stub<Kategorie, KategorieApiModel, KategorieCreate>(
-          kategorien, (k) => k.id),
-      jugendlicheRepo:
-          _Stub<Jugendlicher, JugendlicherApiModel, JugendlicheCreateData>(
-              jugendliche, (j) => j.id),
-      betreuerRepo:
-          _Stub<Betreuer, BetreuerApiModel, ({String name, Gender gender})>(
-              betreuer, (b) => b.id),
-      identityRepo:
-          _Stub<Identity, IdentityApiModel, IdentityCreateData>(
-              identities, (i) => i.id),
-    );
+}) => EintragAssembly(
+  eintragRepo: _Stub<Eintrag, EintragApiModel, EintragCreateData>(
+    eintraege,
+    (e) => e.id,
+  ),
+  kategorieRepo: _Stub<Kategorie, KategorieApiModel, KategorieCreate>(
+    kategorien,
+    (k) => k.id,
+  ),
+  jugendlicheRepo:
+      _Stub<Jugendlicher, JugendlicherApiModel, JugendlicheCreateData>(
+        jugendliche,
+        (j) => j.id,
+      ),
+  betreuerRepo:
+      _Stub<Betreuer, BetreuerApiModel, ({String name, Gender gender})>(
+        betreuer,
+        (b) => b.id,
+      ),
+  identityRepo: _Stub<Identity, IdentityApiModel, IdentityCreateData>(
+    identities,
+    (i) => i.id,
+  ),
+);
 
 _Stub<Signature, SignatureApiModel, SignatureCreateData> _sigRepo(
-        List<Signature> sigs) =>
-    _Stub(sigs, (s) => s.id);
+  List<Signature> sigs,
+) => _Stub(sigs, (s) => s.id);
 
 // ---------------------------------------------------------------------------
 
 void main() {
   setUpAll(() async {
     final pair = await crypto.KeyPair.generateAsync(
-      identity: crypto.KeyOwner('Test Name', 'Gruppenführer', 'test@example.com'),
+      identity: crypto.KeyOwner(
+        'Test Name',
+        'Gruppenführer',
+        'test@example.com',
+      ),
       password: 'test-password',
       keySize: 1024,
     );
@@ -155,7 +170,10 @@ void main() {
         identities: [identity],
       );
 
-      final result = await assembly.assemble('e1', _sigRepo([_sig('e1', 'i1')]));
+      final result = await assembly.assemble(
+        'e1',
+        _sigRepo([_sig('e1', 'i1')]),
+      );
 
       expect(result, isA<Success<SelectedEintrag>>());
       final s = result.unwrap();
@@ -213,42 +231,42 @@ void main() {
       expect(s.entschuldigteJugendliche.single.id, 'j3');
     });
 
-    test('signature identity enrichment — identity joined, isValid propagated',
-        () async {
-      final id1 = _identity('i1');
-      final id2 = _identity('i2');
-      final sig1 = _sig('e1', 'i1');
-      final sig2 = Signature(
-        eintragId: 'e1',
-        identityId: 'i2',
-        signature: crypto.Signature(Uint8List.fromList([9, 8, 7])),
-        timestamp: DateTime(2024),
-        version: 4,
-        isValid: false,
-      );
+    test(
+      'signature identity enrichment — identity joined, isValid propagated',
+      () async {
+        final id1 = _identity('i1');
+        final id2 = _identity('i2');
+        final sig1 = _sig('e1', 'i1');
+        final sig2 = Signature(
+          eintragId: 'e1',
+          identityId: 'i2',
+          signature: crypto.Signature(Uint8List.fromList([9, 8, 7])),
+          timestamp: DateTime(2024),
+          version: 4,
+          isValid: false,
+        );
 
-      final assembly = _assembly(
-        eintraege: [_eintrag()],
-        kategorien: [_kategorie('k1')],
-        identities: [id1, id2],
-      );
+        final assembly = _assembly(
+          eintraege: [_eintrag()],
+          kategorien: [_kategorie('k1')],
+          identities: [id1, id2],
+        );
 
-      final result =
-          await assembly.assemble('e1', _sigRepo([sig1, sig2]));
+        final result = await assembly.assemble('e1', _sigRepo([sig1, sig2]));
 
-      final s = result.unwrap();
-      expect(s.signatures, hasLength(2));
-      final byIdentityId = {for (final sig in s.signatures) sig.identity.id: sig};
-      expect(byIdentityId['i1']!.isValid, isTrue);
-      expect(byIdentityId['i2']!.isValid, isFalse);
-      expect(s.possibleSigners.map((i) => i.id).toSet(), {'i1', 'i2'});
-    });
+        final s = result.unwrap();
+        expect(s.signatures, hasLength(2));
+        final byIdentityId = {
+          for (final sig in s.signatures) sig.identity.id: sig,
+        };
+        expect(byIdentityId['i1']!.isValid, isTrue);
+        expect(byIdentityId['i2']!.isValid, isFalse);
+        expect(s.possibleSigners.map((i) => i.id).toSet(), {'i1', 'i2'});
+      },
+    );
 
     test('eintrag not found — returns Failure', () async {
-      final assembly = _assembly(
-        eintraege: [],
-        kategorien: [_kategorie('k1')],
-      );
+      final assembly = _assembly(eintraege: [], kategorien: [_kategorie('k1')]);
 
       final result = await assembly.assemble('e-missing', _sigRepo([]));
 
@@ -265,5 +283,49 @@ void main() {
 
       expect(result, isA<Failure<SelectedEintrag>>());
     });
+
+    test('undefinierteJugendliche resolved correctly', () async {
+      final eintrag = _eintrag(undefinierteIds: {'j1', 'j2'});
+
+      final assembly = _assembly(
+        eintraege: [eintrag],
+        kategorien: [_kategorie('k1')],
+        jugendliche: [_jugendlicher('j1'), _jugendlicher('j2')],
+      );
+
+      final result = await assembly.assemble('e1', _sigRepo([]));
+
+      expect(result, isA<Success<SelectedEintrag>>());
+      final s = result.unwrap();
+      expect(s.undefinierteJugendliche.map((j) => j.id).toSet(), {'j1', 'j2'});
+    });
+
+    test(
+      'all three attendance groups simultaneously — each ID in correct list',
+      () async {
+        final eintrag = _eintrag(
+          anwesendeIds: {'j1'},
+          entschuldigteIds: {'j2'},
+          undefinierteIds: {'j3'},
+        );
+
+        final assembly = _assembly(
+          eintraege: [eintrag],
+          kategorien: [_kategorie('k1')],
+          jugendliche: [
+            _jugendlicher('j1'),
+            _jugendlicher('j2'),
+            _jugendlicher('j3'),
+          ],
+        );
+
+        final result = await assembly.assemble('e1', _sigRepo([]));
+
+        final s = result.unwrap();
+        expect(s.anwesendeJugendliche.single.id, 'j1');
+        expect(s.entschuldigteJugendliche.single.id, 'j2');
+        expect(s.undefinierteJugendliche.single.id, 'j3');
+      },
+    );
   });
 }

--- a/test/view_model/dashboard_viewmodel_test.dart
+++ b/test/view_model/dashboard_viewmodel_test.dart
@@ -88,6 +88,7 @@ Eintrag _eintrag({
   betreuerIds: const {},
   anwesendeJugendlicherIds: anwesendeIds,
   entschuldigteJugendlicherIds: const {},
+  undefinierteJugendlicherIds: const {},
 );
 
 Kategorie _kategorie(String id) => Kategorie(id: id, name: 'Kategorie $id');


### PR DESCRIPTION
## Summary

- Added `undefinierteJugendlicherIds: Set<String>` to `Eintrag` and mapped it from `EintragApiModel` in `fromApiModel()`
- Added `undefinierteJugendliche: List<Jugendlicher>` to `SelectedEintrag`
- `EintragAssembly.assemble()` now resolves the new IDs into `Jugendlicher` objects analogously to the two existing attendance lists

## Test plan

- [x] Existing assembly tests updated: `_eintrag()` fixture includes `undefinierteJugendlicherIds: const {}`
- [x] New test: `undefinierteJugendliche` resolved correctly from IDs
- [x] New test: all three attendance groups simultaneously — each ID lands in the correct list
- [x] `dashboard_viewmodel_test.dart` fixture updated with the new required field
- [x] `dart analyze` reports no issues
- [x] All 8 assembly tests pass

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)