### PR TITLE
Show log file path in About dialog

### DIFF
--- a/lib/ui/widgets/about.dart
+++ b/lib/ui/widgets/about.dart
@@ -1,16 +1,22 @@
-import 'package:flutter/material.dart';
+import 'dart:io';
 
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../provider/logging/logging.dart';
 import '../../pubspec.g.dart';
 import 'logo.dart';
 
-class AboutButton extends StatelessWidget {
+class AboutButton extends ConsumerWidget {
   const AboutButton({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final logPath = ref.watch(loggingServiceProvider);
     return IconButton(
       onPressed: () {
-        showJulogAbout(context);
+        showJulogAbout(context, logPath: logPath);
       },
       icon: const Icon(Icons.info_outline),
       tooltip: 'Über julog',
@@ -18,9 +24,10 @@ class AboutButton extends StatelessWidget {
   }
 }
 
-void showJulogAbout(BuildContext context) {
+void showJulogAbout(BuildContext context, {String? logPath}) {
   final authors = Pubspec.contributors.join(', ');
   final year = DateTime.now().year;
+  final logFileExists = logPath != null && File(logPath).existsSync();
   showAboutDialog(
     context: context,
     applicationName: Pubspec.name,
@@ -44,6 +51,42 @@ void showJulogAbout(BuildContext context) {
           softWrap: true,
         ),
       ),
+      if (logFileExists) _LogFileSection(logPath: logPath),
     ],
   );
+}
+
+class _LogFileSection extends StatelessWidget {
+  final String logPath;
+  const _LogFileSection({required this.logPath});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(top: 10.0),
+      constraints: BoxConstraints.loose(const Size.fromWidth(200)),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Logdatei', style: TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 4),
+          SelectableText(logPath, style: const TextStyle(fontSize: 12)),
+          TextButton.icon(
+            onPressed: () async {
+              await Clipboard.setData(ClipboardData(text: logPath));
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Pfad in Zwischenablage kopiert'),
+                  ),
+                );
+              }
+            },
+            icon: const Icon(Icons.copy, size: 16),
+            label: const Text('Pfad kopieren'),
+          ),
+        ],
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- `AboutButton` converted from `StatelessWidget` to `ConsumerWidget` to read `loggingServiceProvider`
- `showJulogAbout()` gains an optional `logPath` parameter
- New `_LogFileSection` widget appended to the About dialog children when the log file exists: shows the full path as selectable text and a "Pfad kopieren" button that writes to the clipboard and confirms with a SnackBar

Closes #183

## Test plan

- [x] Open the About dialog — log file section is visible only after at least one signing attempt (file exists)
- [x] "Pfad kopieren" copies the path to clipboard and shows the SnackBar confirmation
- [x] About dialog works normally when no log file exists yet
- [x] `dart analyze` reports no issues ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)