### PR TITLE
Wire up PDF export button in EintragScreen

### DIFF
--- a/lib/ui/eintrag/eintrag_screen.dart
+++ b/lib/ui/eintrag/eintrag_screen.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:printing/printing.dart';
 
 import '../../router/router.dart';
 import '../../view_model/eintrag/eintrag_viewmodel.dart';
+import '../../view_model/eintrag/selected_eintrag_viewmodel.dart';
 import '../list_detail/list_detail.dart';
 import 'eintrag_form.dart';
 import 'eintrag_widget.dart';
+import 'pdf_export.dart';
 
 class EintragScreen extends ConsumerWidget {
   final String? eintragId;
@@ -43,6 +46,25 @@ class EintragScreen extends ConsumerWidget {
               'Wähle einen Eintrag aus der Liste aus, um Details zu sehen.',
             ),
           ),
+          actionsBuilder: (context, selectedIndex) {
+            if (selectedIndex == null) return null;
+            final eintragId = eintrage[selectedIndex].id;
+            return [
+              IconButton(
+                icon: const Icon(Icons.picture_as_pdf),
+                onPressed: () async {
+                  final selectedEintrag = ref
+                      .read(selectedEintragViewModelProvider(eintragId))
+                      .valueOrNull;
+                  if (selectedEintrag == null) return;
+                  await Printing.layoutPdf(
+                    onLayout: (_) =>
+                        generateEintragPdf(eintrag: selectedEintrag),
+                  );
+                },
+              ),
+            ];
+          },
           form: EintragForm(
             onSave:
                 (

--- a/lib/ui/eintrag/eintrag_screen.dart
+++ b/lib/ui/eintrag/eintrag_screen.dart
@@ -55,7 +55,7 @@ class EintragScreen extends ConsumerWidget {
                 onPressed: () async {
                   final selectedEintrag = ref
                       .read(selectedEintragViewModelProvider(eintragId))
-                      .valueOrNull;
+                      .value;
                   if (selectedEintrag == null) return;
                   await Printing.layoutPdf(
                     onLayout: (_) =>


### PR DESCRIPTION
Closes #178

## Summary

- Adds `actionsBuilder` to `ListDetailLayout` in `EintragScreen`
- Renders an `Icons.picture_as_pdf` `IconButton` only when an Eintrag is selected (`selectedIndex != null`)
- On press, reads the already-loaded `SelectedEintrag` from `selectedEintragViewModelProvider` and opens the system print dialog via `Printing.layoutPdf`

## Test plan

- [x] Open the Einträge screen with no item selected — confirm no PDF button is visible
- [x] Select an Eintrag — confirm the PDF button appears in the top-right of the detail pane
- [x] Press the PDF button — confirm the system print dialog opens with the Eintrag content
- [x] `dart analyze` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)