### PR TITLE
Add ADR-0006, ADR-0007 and agent docs for logging feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/adr/0006-logging-uses-dart-logging-with-custom-file-handler.md
+++ b/docs/adr/0006-logging-uses-dart-logging-with-custom-file-handler.md
@@ -1,0 +1,18 @@
+# ADR-0006: Logging uses dart:logging with a custom file handler
+
+**Status**: Accepted
+
+## Context
+
+The app needed structured error logging so that end users can send diagnostic information to the developer. Several third-party packages exist (flutter_logs, omni_logger, etc.) but carry low download counts and inconsistent quality. Dart ships an official `logging` package (publisher: dart.dev, 6.9M downloads) that provides the standard Logger/Level/LogRecord API used across the Dart ecosystem — the same conceptual model as `java.util.logging` and Python's `logging` module. It intentionally ships without file output; consumers attach their own handlers via `Logger.root.onRecord`.
+
+## Decision
+
+We use `logging` (dart.dev) as the logging API throughout the app and write a thin `LogFileHandler` (~50 lines) that listens to `Logger.root.onRecord` and maintains a rolling buffer of 100 entries in a plain-text file under `getApplicationSupportDirectory()`. No third-party file-logging package is added.
+
+## Consequences
+
+- Any part of the app can use `Logger('component-name')` without depending on our own infrastructure — only the `LogFileHandler` wiring in main needs to know about the file.
+- The rolling buffer keeps the log file small enough to email; older entries are silently dropped.
+- A future developer must not mistake "no third-party logging package" for an oversight — the custom handler was a deliberate choice to avoid low-quality dependencies.
+- Switching the output format or storage strategy only requires changing `LogFileHandler`, not call sites.

--- a/docs/adr/0007-log-entries-contain-uuids-only-no-plain-text-names.md
+++ b/docs/adr/0007-log-entries-contain-uuids-only-no-plain-text-names.md
@@ -1,0 +1,17 @@
+# ADR-0007: Log entries contain UUIDs only, no plain-text names
+
+**Status**: Accepted
+
+## Context
+
+The app stores personal data about Jugendliche and Betreuer. Log entries are written to a plain-text file that end users are expected to email to the developer for diagnosis. Including names (Jugendlicher names, Identity names) in log entries would make the file a personal-data artefact subject to data-protection requirements and uncomfortable to share.
+
+## Decision
+
+Log entries may include UUIDs (Eintrag IDs, Identity IDs), exception types, stack traces, and technical metadata. Plain-text names of any person are never written to the log. The developer can cross-reference UUIDs against the user's database file if a specific record needs to be inspected.
+
+## Consequences
+
+- Log files can be emailed without data-protection concerns.
+- A future developer adding logging must actively resist the temptation to include names for "easier debugging" — this ADR is the reason not to.
+- Diagnosing issues that depend on the specific content of a record (e.g. a name with unusual characters) requires the user to share their database file separately, which they may be unwilling to do.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Closes #179

## Summary

All code for issue #179 was already implemented through sub-issues (#180–#184) and merged to main. The only missing artifacts were the two ADRs referenced in the spec and the agent configuration docs:

- `docs/adr/0006-logging-uses-dart-logging-with-custom-file-handler.md` — decision to use dart:logging + custom LogFileHandler instead of a third-party package
- `docs/adr/0007-log-entries-contain-uuids-only-no-plain-text-names.md` — privacy decision to exclude plain-text names from log entries
- `CLAUDE.md` — project instructions for Claude Code (references issue-tracker, triage-labels, and domain docs conventions)
- `docs/agents/issue-tracker.md` — how to use `gh` CLI for issue operations
- `docs/agents/triage-labels.md` — canonical label vocabulary mapping

## Test plan

- [ ] `dart analyze` reports no issues ✅ (verified before push)
- [ ] All existing tests pass (no code changes — only documentation added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)