### PR TITLE
Add ADR-0003, ADR-0004, ADR-0005 for Eintrag PDF export

### DIFF
--- a/docs/adr/0003-pdf-export-uses-ad-hoc-selection-no-veranstaltung.md
+++ b/docs/adr/0003-pdf-export-uses-ad-hoc-selection-no-veranstaltung.md
@@ -1,0 +1,17 @@
+# ADR-0003: PDF export uses ad-hoc Jugendliche selection — no persistent Veranstaltung entity
+
+**Status**: Accepted
+
+## Context
+
+The PDF export feature was motivated by the need to generate registration lists for events (e.g. a camp or excursion) that require prior sign-up. This use case naturally suggests introducing a persistent `Veranstaltung` (event) entity that stores a named event and its registered Jugendliche, which could then be exported.
+
+## Decision
+
+No `Veranstaltung` entity is introduced. The export is ad-hoc: the user selects a title, fields, and a subset of Jugendliche at export time. Nothing is persisted between exports.
+
+## Consequences
+
+- The domain model stays simpler — no new table, no registration lifecycle.
+- Export configurations cannot be saved or reused; the user repeats field and Jugendliche selection each time.
+- If a persistent Veranstaltung concept is needed in the future (e.g. to track which Jugendliche attended a specific event over time), it will require a new domain entity and schema migration. This ADR should be revisited at that point.

--- a/docs/adr/0004-eintrag-pdf-includes-cryptographic-signature-for-audit.md
+++ b/docs/adr/0004-eintrag-pdf-includes-cryptographic-signature-for-audit.md
@@ -1,0 +1,18 @@
+# ADR-0004: Eintrag PDF export includes cryptographic signature value and version for audit
+
+**Status**: Accepted
+
+## Context
+
+The Eintrag PDF export renders a human-readable representation of a group session record. Each Eintrag can carry one or more cryptographic signatures (Ed25519/SHA512). The question is whether the PDF should include only the human-readable metadata of each signature (signer name, function, timestamp, validity) or also the raw cryptographic artefacts (signing version and Base64-encoded signature value).
+
+## Decision
+
+The PDF includes the full Base64-encoded signature value and the signing version for every signature, rendered in a small monospace font with line wrapping. The human-readable fields (signer name, function, timestamp, validity) are shown alongside them.
+
+## Consequences
+
+- The PDF can serve as a self-contained audit document: anyone with the signer's public key can independently verify the signature without querying the database.
+- The Base64 value (~88 characters for a SHA512 signature) adds visual noise but remains on one or two lines at small font sizes.
+- The signing version is required context for verification, since the signing payload schema differs between versions.
+- Changing the display format (e.g. switching to hex or truncating) would silently break any external audit process that relies on copy-pasting the value from the PDF.

--- a/docs/adr/0005-selected-eintrag-exposes-undefiniert-jugendliche.md
+++ b/docs/adr/0005-selected-eintrag-exposes-undefiniert-jugendliche.md
@@ -1,0 +1,23 @@
+# ADR-0005: SelectedEintrag exposes Jugendliche with undefiniert Anwesenheit as a third list
+
+**Status**: Accepted
+
+## Context
+
+The `Eintrag` domain model tracks attendance via two sets: `anwesendeJugendlicherIds` and `entschuldigteJugendlicherIds`. Jugendliche linked to an Eintrag via the `eintrag_jugendlicher` junction table with status `undefiniert` (status ≠ 1 and ≠ 2) are stored in the database but were silently dropped when parsing the API model. They do not appear in the UI.
+
+The signing payload (v5) is derived directly from the database and includes all linked Jugendliche regardless of status, with both `anwesend` and `entschuldigt` flags set to 0 for undefiniert ones. This means an Eintrag whose PDF omits undefiniert Jugendliche would not fully reflect the data that was actually signed.
+
+In practice, undefiniert Jugendliche occur frequently (attendance is not always fully recorded at session time).
+
+## Decision
+
+`EintragApiModel` and `Eintrag` are extended with an `undefinierteJugendlicherIds` set. `SelectedEintrag` (the assembled view model) gains a third list `undefinierteJugendliche: List<Jugendlicher>`, resolved by `EintragAssembly`. The Eintrag PDF export renders them as a separate group ("Nicht erfasst").
+
+The main Eintrag UI display (`EintragDisplay`) does not yet show this third group — that is a separate concern.
+
+## Consequences
+
+- The PDF accurately represents all Jugendliche that were part of the signed data.
+- `EintragApiModel` and `Eintrag` now carry a field that was previously implicit (silently zero), which is a breaking change for callers that construct these models directly (e.g. tests).
+- A future reader must not collapse the three attendance lists back into two without revisiting the signing payload schema and the PDF export.


### PR DESCRIPTION
Closes #174

## Summary

- Commits the three ADRs documenting architectural decisions made during the Eintrag PDF export feature
- **ADR-0003**: PDF export uses ad-hoc Jugendliche selection — no persistent Veranstaltung entity
- **ADR-0004**: Eintrag PDF includes cryptographic signature value and version for audit
- **ADR-0005**: SelectedEintrag exposes Jugendliche with undefiniert Anwesenheit as a third list

All code changes (implementation + tests) for this feature were delivered through sub-issues #176, #177, #178. This PR closes the parent issue by landing the corresponding decision records.

## Test plan
- [x] `dart analyze` — no errors
- [x] `flutter test` — all tests pass (43/43 as of main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)