### PR TITLE
Track agent docs, exclude Claude Code local files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,8 @@ app.*.map.json
 *.g.dart
 *.freezed.dart
 
-domain*
+# Claude Code
+.claude/settings.local.json
+.agents/
+skills-lock.json
+.claude/skills/

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_


### PR DESCRIPTION
## Summary

- Removes the overbroad `domain*` gitignore pattern that accidentally excluded `docs/agents/domain.md`; adds that file to version control alongside its already-tracked siblings (`issue-tracker.md`, `triage-labels.md`)
- Adds explicit ignores for Claude Code local setup files (`.claude/settings.local.json`, `.claude/skills/`, `.agents/`, `skills-lock.json`) — these are machine-specific and not useful in a solo project repo

## Test plan

- [ ] Verify `docs/agents/domain.md` is tracked and matches its siblings in style
- [ ] Verify none of the Claude Code local paths appear as untracked files after checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)