### PR TITLE
Add release and tag-release scripts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+
+BUMP_TYPE="${1:-}"
+
+if [[ "$BUMP_TYPE" != "major" && "$BUMP_TYPE" != "minor" && "$BUMP_TYPE" != "patch" ]]; then
+  echo "Usage: $0 <major|minor|patch>"
+  exit 1
+fi
+
+dart pub bump "$BUMP_TYPE"
+
+# Extract version without build number (3.1.0+1 -> 3.1.0)
+VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //;s/+.*//')
+
+echo "Bumped to $VERSION"
+
+# Update README
+sed -i "s/Aktuelle Version: \*\*[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\*\*/Aktuelle Version: **$VERSION**/" README.md
+
+# Update Inno Setup installer display name
+sed -i "s/AppVerName=Julog .*/AppVerName=Julog $VERSION/" windows/innosetup/setup.iss
+
+BRANCH="release-$(echo "$VERSION" | tr '.' '-')"
+
+git checkout -b "$BRANCH"
+git add pubspec.yaml README.md windows/innosetup/setup.iss
+git commit -m "Release $VERSION"
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --title "Release $VERSION" \
+  --body "Bump version to $VERSION." \
+  --base main
+
+gh pr merge --auto --squash
+
+echo ""
+echo "PR opened and set to auto-merge. Once it lands on main, run:"
+echo "  ./scripts/tag-release.sh $VERSION"

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>  (e.g. 3.2.0)"
+  exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "Error: must be on main (currently on '$CURRENT_BRANCH')"
+  echo "Run: git checkout main && git pull"
+  exit 1
+fi
+
+git fetch origin main
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [[ "$LOCAL" != "$REMOTE" ]]; then
+  echo "Error: main is not up to date with origin/main. Run: git pull"
+  exit 1
+fi
+
+TAG="v$VERSION"
+git tag -s "$TAG" -m "Release $TAG"
+git push origin "$TAG"
+
+echo ""
+echo "Tag $TAG pushed. GitHub Actions will build and create a draft release."
+echo "Review the draft at: https://github.com/pbarbenheim/julog/releases"
+echo "Publish it there when ready."


### PR DESCRIPTION
## Summary
- `scripts/release.sh <major|minor|patch>` — bumps the version via `dart pub bump`, updates `README.md` and `windows/innosetup/setup.iss`, then opens a PR on a release branch with auto-merge enabled
- `scripts/tag-release.sh <version>` — guards that `main` is up to date, then creates a signed tag and pushes it to trigger the GitHub Actions release build

## Test plan
- [ ] Run `./scripts/release.sh patch` on a test branch and verify all three version locations are updated correctly
- [ ] Verify the PR is opened and auto-merge is set
- [ ] After merge, run `./scripts/tag-release.sh <version>` and verify the signed tag appears on GitHub and the release workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)