### PR TITLE
Add edit and delete for unsignierte Einträge

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,3 +29,12 @@ A group leader/supervisor. Linked to Einträge as facilitators.
 
 ## Kategorie
 A classification tag for an Eintrag.
+
+## Signatur
+A cryptographic signature (Ed25519/SHA512) attached to an Eintrag by an Identity. An Eintrag may carry zero or more Signaturen. Each Signatur records the signer's Identity, a timestamp, a version, and a validity flag.
+
+## Unsignierter Eintrag
+An Eintrag that carries zero Signaturen. An unsignierter Eintrag is considered a draft — it has not yet been finalised and may be edited or deleted. Once any Signatur is added (regardless of validity), the Eintrag is considered signiert and can no longer be modified or deleted.
+
+## Signierter Eintrag
+An Eintrag that carries at least one Signatur. A signierter Eintrag is considered finalised and is immutable — it cannot be edited or deleted.

--- a/docs/adr/0008-any-signature-locks-eintrag.md
+++ b/docs/adr/0008-any-signature-locks-eintrag.md
@@ -1,0 +1,5 @@
+# ADR-0008: Any Signatur — including an invalid one — makes an Eintrag immutable
+
+An Eintrag without any Signatur is considered a draft and may be edited or deleted. Once any Signatur is attached, the Eintrag is considered finalised and can no longer be modified or deleted, even if that Signatur's `isValid` flag is `false`.
+
+The alternative would be to treat only *valid* Signaturen as locking. This was rejected because an invalid Signatur still proves that someone attempted to sign — and therefore reviewed — the Eintrag at a point in time. Allowing edits after an invalid signature would let the content silently diverge from what the signer saw, which defeats the audit purpose. If a signature is invalid (e.g. corrupted key or tampered data), the correct response is to investigate, not to quietly edit the underlying record.

--- a/lib/repository/eintrag/eintrag_repo.dart
+++ b/lib/repository/eintrag/eintrag_repo.dart
@@ -24,12 +24,61 @@ typedef EintragCreateData = ({
   List<String> entschuldigteJugendlicherIds,
 });
 
+typedef EintragUpdateData = ({
+  String id,
+  DateTime start,
+  DateTime end,
+  String kategorieId,
+  String thema,
+  String? ort,
+  String? raum,
+  String? dienstverlauf,
+  String? besonderheiten,
+  List<String> betreuerIds,
+  List<String> anwesendeJugendlicherIds,
+  List<String> entschuldigteJugendlicherIds,
+});
+
 class EintragRepository
     extends JulogRepository<Eintrag, EintragApiModel, EintragCreateData>
     implements EintragSigningDataSource {
   final Jldb _jldb;
 
   EintragRepository({required Jldb jldb}) : _jldb = jldb;
+
+  AsyncVoidResult delete(String id) async {
+    final result = await _jldb.deleteEintrag(UUID.fromString(id));
+    if (result is Failure<Unit>) return Failure(result.error);
+    invalidateCache();
+    return Result.voidSuccess();
+  }
+
+  AsyncVoidResult update(EintragUpdateData data) async {
+    final result = await _jldb.updateEintrag(
+      EintragApiModel(
+        id: UUID.fromString(data.id),
+        start: data.start,
+        end: data.end,
+        kategorieId: UUID.fromString(data.kategorieId),
+        thema: data.thema,
+        ort: data.ort,
+        raum: data.raum,
+        dienstverlauf: data.dienstverlauf,
+        besonderheiten: data.besonderheiten,
+        betreuerIds: data.betreuerIds.map(UUID.fromString).toSet(),
+        anwesendeJugendlicherIds: data.anwesendeJugendlicherIds
+            .map(UUID.fromString)
+            .toSet(),
+        entschuldigteJugendlicherIds: data.entschuldigteJugendlicherIds
+            .map(UUID.fromString)
+            .toSet(),
+        undefinierteJugendlicherIds: const {},
+      ),
+    );
+    if (result is Failure<Unit>) return Failure(result.error);
+    invalidateCache();
+    return Result.voidSuccess();
+  }
 
   @override
   AsyncResult<Optional<String>> getEintragSigningData(

--- a/lib/ui/eintrag/eintrag_form.dart
+++ b/lib/ui/eintrag/eintrag_form.dart
@@ -6,6 +6,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../view_model/eintrag/eintrag_form_viewmodel.dart';
 import '../widgets/datetime_picker.dart';
 
+class EintragInitialValues {
+  final DateTime start;
+  final DateTime end;
+  final String kategorieId;
+  final String thema;
+  final String? ort;
+  final String? raum;
+  final String? dienstverlauf;
+  final String? besonderheiten;
+  final List<String> betreuerIds;
+  final Map<String, Anwesenheit> jugendliche;
+
+  const EintragInitialValues({
+    required this.start,
+    required this.end,
+    required this.kategorieId,
+    required this.thema,
+    this.ort,
+    this.raum,
+    this.dienstverlauf,
+    this.besonderheiten,
+    required this.betreuerIds,
+    required this.jugendliche,
+  });
+}
+
 class EintragForm extends ConsumerStatefulWidget {
   final FutureOr<void> Function(
     DateTime start,
@@ -21,7 +47,9 @@ class EintragForm extends ConsumerStatefulWidget {
     List<String> entschuldigteJugendlicherIds,
   )?
   onSave;
-  const EintragForm({super.key, this.onSave});
+  final EintragInitialValues? initialValues;
+
+  const EintragForm({super.key, this.onSave, this.initialValues});
 
   @override
   ConsumerState<EintragForm> createState() => _EintragFormState();
@@ -29,25 +57,54 @@ class EintragForm extends ConsumerStatefulWidget {
 
 class _EintragFormState extends ConsumerState<EintragForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final TextEditingController _themaController = TextEditingController();
-  final TextEditingController _ortController = TextEditingController();
-  final TextEditingController _raumController = TextEditingController();
-  final TextEditingController _dienstverlaufController =
-      TextEditingController();
-  final TextEditingController _besonderheitenController =
-      TextEditingController();
+  late final TextEditingController _themaController;
+  late final TextEditingController _ortController;
+  late final TextEditingController _raumController;
+  late final TextEditingController _dienstverlaufController;
+  late final TextEditingController _besonderheitenController;
 
   DateTime? _start;
   DateTime? _end;
   String? _kategorieId;
-  final List<String> _betreuerIds = [];
-  final Map<String, Anwesenheit> _jugendliche = {};
+  late List<String> _betreuerIds;
+  late Map<String, Anwesenheit> _jugendliche;
 
   bool _loading = false;
 
   @override
+  void initState() {
+    super.initState();
+    final iv = widget.initialValues;
+    _themaController = TextEditingController(text: iv?.thema ?? '');
+    _ortController = TextEditingController(text: iv?.ort ?? '');
+    _raumController = TextEditingController(text: iv?.raum ?? '');
+    _dienstverlaufController = TextEditingController(
+      text: iv?.dienstverlauf ?? '',
+    );
+    _besonderheitenController = TextEditingController(
+      text: iv?.besonderheiten ?? '',
+    );
+    _start = iv?.start;
+    _end = iv?.end;
+    _kategorieId = iv?.kategorieId;
+    _betreuerIds = List.of(iv?.betreuerIds ?? []);
+    _jugendliche = Map.of(iv?.jugendliche ?? {});
+  }
+
+  @override
+  void dispose() {
+    _themaController.dispose();
+    _ortController.dispose();
+    _raumController.dispose();
+    _dienstverlaufController.dispose();
+    _besonderheitenController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final options = ref.watch(eintragFormViewmodelProvider);
+    final isEdit = widget.initialValues != null;
     return options.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stack) => Center(child: Text('Fehler: $error')),
@@ -63,15 +120,12 @@ class _EintragFormState extends ConsumerState<EintragForm> {
               child: Column(
                 children: [
                   Text(
-                    'Neuen Eintrag hinzufügen',
+                    isEdit ? 'Eintrag bearbeiten' : 'Neuen Eintrag hinzufügen',
                     style: Theme.of(context).textTheme.headlineMedium,
                   ),
                   const SizedBox(height: 16),
                   DateTimePickerFormField(
-                    firstDate: DateTime.now().subtract(
-                      const Duration(days: 30),
-                    ),
-                    lastDate: DateTime.now().add(const Duration(days: 2)),
+                    initialValue: _start,
                     labelText: 'Startzeit',
                     onSaved: (newValue) => _start = newValue,
                     onChanged: (value) {
@@ -86,10 +140,7 @@ class _EintragFormState extends ConsumerState<EintragForm> {
                   ),
                   const SizedBox(height: 16),
                   DateTimePickerFormField(
-                    firstDate: DateTime.now().subtract(
-                      const Duration(days: 30),
-                    ),
-                    lastDate: DateTime.now().add(const Duration(days: 2)),
+                    initialValue: _end,
                     labelText: 'Endzeit',
                     onSaved: (newValue) => _end = newValue,
                     validator: (value) {
@@ -106,6 +157,7 @@ class _EintragFormState extends ConsumerState<EintragForm> {
                   const SizedBox(height: 16),
                   DropdownMenuFormField(
                     label: const Text('Kategorie'),
+                    initialSelection: _kategorieId,
                     dropdownMenuEntries: kategorien.entries
                         .map(
                           (e) =>

--- a/lib/ui/eintrag/eintrag_screen.dart
+++ b/lib/ui/eintrag/eintrag_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jlcore/jlcore.dart';
 import 'package:printing/printing.dart';
 
 import '../../router/router.dart';
@@ -10,12 +11,32 @@ import 'eintrag_form.dart';
 import 'eintrag_widget.dart';
 import 'pdf_export.dart';
 
-class EintragScreen extends ConsumerWidget {
+class EintragScreen extends ConsumerStatefulWidget {
   final String? eintragId;
   const EintragScreen({super.key, this.eintragId});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<EintragScreen> createState() => _EintragScreenState();
+}
+
+class _EintragScreenState extends ConsumerState<EintragScreen> {
+  int? _selectedIndex;
+  bool _editMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  void _onSelectionChanged(int? index) {
+    setState(() {
+      _selectedIndex = index;
+      _editMode = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final eintragIdsValue = ref.watch(eintragViewModelProvider);
     return eintragIdsValue.when(
       loading: () => const Center(child: CircularProgressIndicator()),
@@ -32,15 +53,16 @@ class EintragScreen extends ConsumerWidget {
               ),
             )
             .toList();
-        var index = eintragId != null
-            ? eintrage.indexWhere((element) => element.id == eintragId)
-            : null;
-        if (index == -1) {
-          index = null;
-        }
+
+        int? initialIndex = widget.eintragId != null
+            ? eintrage.indexWhere((e) => e.id == widget.eintragId)
+            : _selectedIndex;
+        if (initialIndex == -1) initialIndex = null;
+
         return ListDetailLayout(
           items: items,
-          initialSelectedIndex: index,
+          initialSelectedIndex: initialIndex,
+          onSelectionChanged: _onSelectionChanged,
           emptyDetail: const Center(
             child: Text(
               'Wähle einen Eintrag aus der Liste aus, um Details zu sehen.',
@@ -49,17 +71,42 @@ class EintragScreen extends ConsumerWidget {
           actionsBuilder: (context, selectedIndex) {
             if (selectedIndex == null) return null;
             final eintragId = eintrage[selectedIndex].id;
+            final eintragAsync = ref.watch(
+              selectedEintragViewModelProvider(eintragId),
+            );
+            final selectedEintrag = eintragAsync.value;
+            final isUnsigned =
+                selectedEintrag != null && selectedEintrag.signatures.isEmpty;
+
             return [
+              if (isUnsigned && !_editMode) ...[
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  tooltip: 'Eintrag bearbeiten',
+                  onPressed: () => setState(() => _editMode = true),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  tooltip: 'Eintrag löschen',
+                  onPressed: () =>
+                      _confirmDelete(context, eintragId, selectedIndex),
+                ),
+              ],
+              if (_editMode)
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Bearbeitung abbrechen',
+                  onPressed: () => setState(() => _editMode = false),
+                ),
               IconButton(
                 icon: const Icon(Icons.picture_as_pdf),
                 onPressed: () async {
-                  final selectedEintrag = ref
+                  final selected = ref
                       .read(selectedEintragViewModelProvider(eintragId))
                       .value;
-                  if (selectedEintrag == null) return;
+                  if (selected == null) return;
                   await Printing.layoutPdf(
-                    onLayout: (_) =>
-                        generateEintragPdf(eintrag: selectedEintrag),
+                    onLayout: (_) => generateEintragPdf(eintrag: selected),
                   );
                 },
               ),
@@ -102,10 +149,144 @@ class EintragScreen extends ConsumerWidget {
           ),
           detailBuilder: (context, index) {
             final selectedEintrag = eintrage[index];
+            if (_editMode) {
+              final eintragAsync = ref.watch(
+                selectedEintragViewModelProvider(selectedEintrag.id),
+              );
+              return eintragAsync.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(child: Text('Fehler: $e')),
+                data: (full) => EintragForm(
+                  initialValues: EintragInitialValues(
+                    start: full.start,
+                    end: full.end,
+                    kategorieId: full.kategorie.id,
+                    thema: full.thema ?? '',
+                    ort: full.ort,
+                    raum: full.raum,
+                    dienstverlauf: full.dienstverlauf,
+                    besonderheiten: full.besonderheiten,
+                    betreuerIds: full.betreuer.map((b) => b.id).toList(),
+                    jugendliche: {
+                      for (final j in full.anwesendeJugendliche)
+                        j.id: Anwesenheit.anwesend,
+                      for (final j in full.entschuldigteJugendliche)
+                        j.id: Anwesenheit.entschuldigt,
+                      for (final j in full.undefinierteJugendliche)
+                        j.id: Anwesenheit.undefiniert,
+                    },
+                  ),
+                  onSave:
+                      (
+                        DateTime start,
+                        DateTime end,
+                        String kategorieId,
+                        String thema,
+                        String? ort,
+                        String? raum,
+                        String? dienstverlauf,
+                        String? besonderheiten,
+                        List<String> betreuerIds,
+                        List<String> anwesendeJugendlicherIds,
+                        List<String> entschuldigteJugendlicherIds,
+                      ) async {
+                        final result = await ref
+                            .read(
+                              selectedEintragViewModelProvider(
+                                selectedEintrag.id,
+                              ).notifier,
+                            )
+                            .editEintrag(
+                              start: start,
+                              end: end,
+                              kategorieId: kategorieId,
+                              thema: thema,
+                              ort: ort,
+                              raum: raum,
+                              dienstverlauf: dienstverlauf,
+                              besonderheiten: besonderheiten,
+                              betreuerIds: betreuerIds,
+                              anwesendeJugendlicherIds:
+                                  anwesendeJugendlicherIds,
+                              entschuldigteJugendlicherIds:
+                                  entschuldigteJugendlicherIds,
+                            );
+                        if (!context.mounted) return;
+                        switch (result) {
+                          case Success<Unit>():
+                            setState(() => _editMode = false);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text(
+                                  'Eintrag erfolgreich gespeichert.',
+                                ),
+                              ),
+                            );
+                          case Failure<Unit>():
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                  'Fehler beim Speichern: ${result.error}',
+                                ),
+                              ),
+                            );
+                        }
+                      },
+                ),
+              );
+            }
             return EintragDisplay(eintragId: selectedEintrag.id);
           },
         );
       },
     );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    String eintragId,
+    int selectedIndex,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Eintrag löschen'),
+        content: const Text(
+          'Dieser Eintrag wird unwiderruflich gelöscht. Fortfahren?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Abbrechen'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Löschen'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    if (!context.mounted) return;
+
+    final result = await ref
+        .read(selectedEintragViewModelProvider(eintragId).notifier)
+        .delete();
+
+    if (!context.mounted) return;
+    switch (result) {
+      case Success<Unit>():
+        setState(() {
+          _selectedIndex = null;
+          _editMode = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Eintrag wurde gelöscht.')),
+        );
+      case Failure<Unit>():
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Fehler beim Löschen: ${result.error}')),
+        );
+    }
   }
 }

--- a/lib/ui/list_detail/screen.dart
+++ b/lib/ui/list_detail/screen.dart
@@ -12,6 +12,7 @@ class ListDetailLayout extends StatefulWidget {
   final List<Widget>? Function(BuildContext context, int? selectedIndex)?
   actionsBuilder;
   final List<Widget>? Function(BuildContext context)? listActionsBuilder;
+  final void Function(int? index)? onSelectionChanged;
 
   const ListDetailLayout({
     super.key,
@@ -23,6 +24,7 @@ class ListDetailLayout extends StatefulWidget {
     this.showEmptyHint = true,
     this.actionsBuilder,
     this.listActionsBuilder,
+    this.onSelectionChanged,
   });
 
   @override
@@ -43,8 +45,18 @@ class _ListDetailLayoutState extends State<ListDetailLayout> {
   void didUpdateWidget(covariant ListDetailLayout oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.initialSelectedIndex != oldWidget.initialSelectedIndex) {
-      _selectedIndex = widget.initialSelectedIndex;
+      setState(() {
+        _selectedIndex = widget.initialSelectedIndex;
+      });
     }
+  }
+
+  void _select(int? index) {
+    setState(() {
+      _selectedIndex = index;
+      if (index != null) _showForm = false;
+    });
+    widget.onSelectionChanged?.call(index);
   }
 
   @override
@@ -121,12 +133,8 @@ class _ListDetailLayoutState extends State<ListDetailLayout> {
                                           selected:
                                               widget.items.indexOf(e) ==
                                               _selectedIndex,
-                                          onTap: () {
-                                            setState(() {
-                                              _selectedIndex = widget.items
-                                                  .indexOf(e);
-                                            });
-                                          },
+                                          onTap: () =>
+                                              _select(widget.items.indexOf(e)),
                                         ),
                                       ),
                                     )
@@ -142,6 +150,7 @@ class _ListDetailLayoutState extends State<ListDetailLayout> {
                                   _selectedIndex = null;
                                   _showForm = true;
                                 });
+                                widget.onSelectionChanged?.call(null);
                               },
                               child: const Icon(Icons.add),
                             ),
@@ -170,11 +179,7 @@ class _ListDetailLayoutState extends State<ListDetailLayout> {
                         children: [
                           if (_selectedIndex != null)
                             IconButton(
-                              onPressed: () {
-                                setState(() {
-                                  _selectedIndex = null;
-                                });
-                              },
+                              onPressed: () => _select(null),
                               icon: const Icon(Icons.arrow_back),
                             ),
                           Expanded(child: Container()),

--- a/lib/ui/widgets/datetime_picker.dart
+++ b/lib/ui/widgets/datetime_picker.dart
@@ -8,8 +8,8 @@ class DateTimePickerFormField extends FormField<DateTime> {
     super.validator,
     ValueChanged<DateTime>? onChanged,
     String labelText = '',
-    required DateTime firstDate,
-    required DateTime lastDate,
+    DateTime? firstDate,
+    DateTime? lastDate,
   }) : super(
          builder: (FormFieldState<DateTime> state) {
            Future<void> pickDateTime(BuildContext context) async {
@@ -18,8 +18,8 @@ class DateTimePickerFormField extends FormField<DateTime> {
              final date = await showDatePicker(
                context: context,
                initialDate: currentValue,
-               firstDate: firstDate,
-               lastDate: lastDate,
+               firstDate: firstDate ?? DateTime(1900),
+               lastDate: lastDate ?? DateTime(2100),
              );
 
              if (date == null) return;

--- a/lib/view_model/eintrag/selected_eintrag_viewmodel.dart
+++ b/lib/view_model/eintrag/selected_eintrag_viewmodel.dart
@@ -2,8 +2,10 @@ import 'package:jldb/jldb.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../assembly/eintrag_assembly.dart';
+import '../../repository/eintrag/eintrag_repo.dart';
 import '../../repository/signature/signature_repository.dart';
 import '../../service/eintrag_signing_service.dart';
+import 'eintrag_viewmodel.dart';
 
 part 'selected_eintrag_viewmodel.g.dart';
 
@@ -14,6 +16,50 @@ class SelectedEintragViewModel extends _$SelectedEintragViewModel {
     final assembly = ref.watch(eintragAssemblyProvider);
     final signatureRepo = ref.watch(signatureRepositoryProvider(id));
     return (await assembly.assemble(id, signatureRepo)).unwrap();
+  }
+
+  AsyncVoidResult delete() {
+    assert(state.hasValue);
+    return Result.voidSafeAsync(() async {
+      final repo = ref.read(eintragRepositoryProvider);
+      await repo.delete(state.asData!.value.id).unwrap();
+      ref.invalidate(eintragViewModelProvider);
+    });
+  }
+
+  AsyncVoidResult editEintrag({
+    required DateTime start,
+    required DateTime end,
+    required String kategorieId,
+    required String thema,
+    String? ort,
+    String? raum,
+    String? dienstverlauf,
+    String? besonderheiten,
+    required List<String> betreuerIds,
+    required List<String> anwesendeJugendlicherIds,
+    required List<String> entschuldigteJugendlicherIds,
+  }) {
+    assert(state.hasValue);
+    return Result.voidSafeAsync(() async {
+      final repo = ref.read(eintragRepositoryProvider);
+      await repo.update((
+        id: state.asData!.value.id,
+        start: start,
+        end: end,
+        kategorieId: kategorieId,
+        thema: thema,
+        ort: ort,
+        raum: raum,
+        dienstverlauf: dienstverlauf,
+        besonderheiten: besonderheiten,
+        betreuerIds: betreuerIds,
+        anwesendeJugendlicherIds: anwesendeJugendlicherIds,
+        entschuldigteJugendlicherIds: entschuldigteJugendlicherIds,
+      )).unwrap();
+      ref.invalidate(eintragViewModelProvider);
+      ref.invalidateSelf();
+    });
   }
 
   AsyncVoidResult sign(String identityId, String password) {

--- a/packages/jldb/lib/src/jldb.dart
+++ b/packages/jldb/lib/src/jldb.dart
@@ -524,6 +524,84 @@ final class Jldb {
     });
   }
 
+  AsyncVoidResult deleteEintrag(UUID id) => Result.voidSafeAsync(() async {
+    final signatures = await getSignaturesByEintragId(id).unwrap();
+    if (signatures.isNotEmpty) {
+      throw Exception(
+        'Eintrag $id hat Signaturen und kann nicht gelöscht werden.',
+      );
+    }
+    await _database.transaction((db) async {
+      await db.execute(
+        'delete from eintrag_jugendlicher where eintrag_id = ?;',
+        [id.toString()],
+      );
+      await db.execute('delete from eintrag_betreuer where eintrag_id = ?;', [
+        id.toString(),
+      ]);
+      await db.execute('delete from eintrag where id = ?;', [id.toString()]);
+    });
+  });
+
+  AsyncVoidResult updateEintrag(
+    EintragApiModel eintrag,
+  ) => Result.voidSafeAsync(() async {
+    await _database.transaction((db) async {
+      await db.execute(
+        '''
+            update eintrag
+            set start = ?, end = ?, kategorie_id = ?, thema = ?, ort = ?,
+                raum = ?, dienstverlauf = ?, besonderheiten = ?
+            where id = ?;
+          ''',
+        [
+          eintrag.start.millisecondsSinceEpoch,
+          eintrag.end.millisecondsSinceEpoch,
+          eintrag.kategorieId.toString(),
+          eintrag.thema,
+          eintrag.ort,
+          eintrag.raum,
+          eintrag.dienstverlauf,
+          eintrag.besonderheiten,
+          eintrag.id.toString(),
+        ],
+      );
+      await db.execute('delete from eintrag_betreuer where eintrag_id = ?;', [
+        eintrag.id.toString(),
+      ]);
+      for (final betreuerId in eintrag.betreuerIds) {
+        await db.execute(
+          'insert into eintrag_betreuer (eintrag_id, betreuer_id) values (?, ?);',
+          [eintrag.id.toString(), betreuerId.toString()],
+        );
+      }
+      await db.execute(
+        'delete from eintrag_jugendlicher where eintrag_id = ?;',
+        [eintrag.id.toString()],
+      );
+      for (final jugendlicherId in eintrag.anwesendeJugendlicherIds) {
+        await db.execute(
+          'insert into eintrag_jugendlicher (eintrag_id, jugendlicher_id, status) values (?, ?, ?);',
+          [
+            eintrag.id.toString(),
+            jugendlicherId.toString(),
+            eintragStatusAnwesend,
+          ],
+        );
+      }
+      for (final jugendlicherId in eintrag.entschuldigteJugendlicherIds) {
+        await db.execute(
+          'insert into eintrag_jugendlicher (eintrag_id, jugendlicher_id, status) values (?, ?, ?);',
+          [
+            eintrag.id.toString(),
+            jugendlicherId.toString(),
+            eintragStatusEntschuldigt,
+          ],
+        );
+      }
+    });
+  });
+
   AsyncVoidResult deleteJugendlicher(UUID id) => Result.voidSafeAsync(() async {
     final current = await getJugendlicher(id).unwrap().unsafe();
     if (current == null) {


### PR DESCRIPTION
Closes #204

## Summary

- Unsignierte Einträge (zero Signaturen) are now editable and deletable via the action bar
- Any Signatur — valid or not — locks the Eintrag permanently (per ADR-0008)
- Date restriction removed from the date/time picker (both create and edit paths)

## Changes

**jldb package**
- `deleteEintrag`: checks for existing Signaturen as a guard, then deletes Eintrag and all relations in a transaction
- `updateEintrag`: replaces the Eintrag row and all relation rows in a transaction

**Repository / ViewModel**
- `EintragRepository`: `delete` and `update` methods (with cache invalidation)
- `SelectedEintragViewModel`: `delete` and `editEintrag` actions

**UI**
- `EintragForm`: accepts optional `EintragInitialValues` to pre-fill all fields for edit mode; title adapts
- `DateTimePickerFormField`: `firstDate`/`lastDate` are now optional (default: unrestricted)
- `ListDetailLayout`: new `onSelectionChanged` callback so parent can track and reset selection
- `EintragScreen`: converted to `ConsumerStatefulWidget`; edit mode shows pre-filled form in the detail panel; delete shows confirmation dialog and SnackBar

**Documentation**
- `CONTEXT.md`: added Signatur, Unsignierter Eintrag, Signierter Eintrag to the glossary
- `docs/adr/0008-any-signature-locks-eintrag.md`: new ADR

## Test plan

- [x] Create an Eintrag → edit button and delete button appear in the action bar
- [x] Click edit → pre-filled form appears; change a field and save → detail view returns with updated data
- [x] Click delete → confirmation dialog appears; cancel → nothing deleted
- [x] Confirm delete → SnackBar confirms deletion, list deselects
- [x] Sign the Eintrag → edit and delete buttons disappear
- [x] All existing tests pass (`flutter test` + `dart test` in packages/jldb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)