### PR TITLE
Show signature status icon in Eintrag list items

### DIFF
--- a/lib/repository/model/eintrag/eintrag_model.dart
+++ b/lib/repository/model/eintrag/eintrag_model.dart
@@ -19,6 +19,7 @@ abstract class Eintrag with _$Eintrag {
     required Set<String> anwesendeJugendlicherIds,
     required Set<String> entschuldigteJugendlicherIds,
     required Set<String> undefinierteJugendlicherIds,
+    required bool isSigned,
   }) = _Eintrag;
 
   static Eintrag fromApiModel(EintragApiModel model) {
@@ -42,6 +43,7 @@ abstract class Eintrag with _$Eintrag {
       undefinierteJugendlicherIds: model.undefinierteJugendlicherIds
           .map((e) => e.toString())
           .toSet(),
+      isSigned: model.isSigned,
     );
   }
 }

--- a/lib/ui/eintrag/eintrag_screen.dart
+++ b/lib/ui/eintrag/eintrag_screen.dart
@@ -47,8 +47,18 @@ class _EintragScreenState extends ConsumerState<EintragScreen> {
             .map(
               (e) => ListItem(
                 title: Text(e.thema),
-                subtitle: Text(
-                  MaterialLocalizations.of(context).formatFullDate(e.start),
+                subtitle: Row(
+                  children: [
+                    Icon(
+                      e.isSigned ? Icons.verified : Icons.edit,
+                      size: 16,
+                      color: e.isSigned ? null : Colors.amber,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      MaterialLocalizations.of(context).formatFullDate(e.start),
+                    ),
+                  ],
                 ),
               ),
             )

--- a/lib/view_model/eintrag/eintrag_viewmodel.dart
+++ b/lib/view_model/eintrag/eintrag_viewmodel.dart
@@ -21,6 +21,7 @@ class EintragViewModel extends _$EintragViewModel {
             start: e.start,
             end: e.end,
             thema: e.thema,
+            isSigned: e.isSigned,
           ),
         )
         .toList();
@@ -72,5 +73,6 @@ abstract class SmallEintrag with _$SmallEintrag {
     required DateTime start,
     required DateTime end,
     required String thema,
+    required bool isSigned,
   }) = _SmallEintrag;
 }

--- a/packages/jldb/lib/src/jldb.dart
+++ b/packages/jldb/lib/src/jldb.dart
@@ -10,7 +10,7 @@ const jldbCompatibleSinceVersion = 3;
 
 final class Jldb {
   static const _getAllEintraegeSql = '''
-    select 
+    select
       e.id,
       e.start,
       e.end,
@@ -21,22 +21,28 @@ final class Jldb {
       e.dienstverlauf,
       e.besonderheiten,
       j.jugendliche,
-      b.betreuer
+      b.betreuer,
+      (sig.eid is not null) as is_signed
     from eintrag as e
       left join (
-        select 
+        select
           ej.eintrag_id as eid,
           group_concat(concat(ej.jugendlicher_id, ':', ej.status), ',') as jugendliche
         from eintrag_jugendlicher as ej
         group by ej.eintrag_id
       ) as j on e.id = j.eid
       left join (
-        select 
+        select
           eb.eintrag_id as eid,
           group_concat(eb.betreuer_id, ',') as betreuer
         from eintrag_betreuer as eb
         group by eb.eintrag_id
       ) as b on e.id = b.eid
+      left join (
+        select eintrag_id as eid
+        from signature
+        group by eintrag_id
+      ) as sig on e.id = sig.eid
       %COND%
   ;
   ''';
@@ -52,6 +58,7 @@ final class Jldb {
     'besonderheiten',
     'status_jugendlicher_ids',
     'betreuer_ids',
+    'is_signed',
   ];
 
   final String filename;

--- a/packages/jldb/lib/src/models/eintrag/eintrag_api_model.dart
+++ b/packages/jldb/lib/src/models/eintrag/eintrag_api_model.dart
@@ -23,6 +23,7 @@ abstract class EintragApiModel with _$EintragApiModel {
     required Set<UUID> anwesendeJugendlicherIds,
     required Set<UUID> entschuldigteJugendlicherIds,
     required Set<UUID> undefinierteJugendlicherIds,
+    @Default(false) bool isSigned,
   }) = _EintragApiModel;
 }
 
@@ -52,6 +53,7 @@ EintragApiModel eintragApiModelFromDbArray(
   final besonderheitenIndex = columns.indexOf('besonderheiten');
   final betreuerIdsIndex = columns.indexOf('betreuer_ids');
   final statusJugendlicherIdsIndex = columns.indexOf('status_jugendlicher_ids');
+  final isSignedIndex = columns.indexOf('is_signed');
 
   final anwesendeJugendlicherIds = <UUID>{};
   final entschuldigteJugendlicherIds = <UUID>{};
@@ -103,5 +105,8 @@ EintragApiModel eintragApiModelFromDbArray(
     anwesendeJugendlicherIds: anwesendeJugendlicherIds,
     entschuldigteJugendlicherIds: entschuldigteJugendlicherIds,
     undefinierteJugendlicherIds: undefinierteJugendlicherIds,
+    isSigned: isSignedIndex != -1
+        ? (data[isSignedIndex] as int? ?? 0) != 0
+        : false,
   );
 }

--- a/test/assembly/eintrag_assembly_test.dart
+++ b/test/assembly/eintrag_assembly_test.dart
@@ -82,6 +82,7 @@ Eintrag _eintrag({
   anwesendeJugendlicherIds: anwesendeIds,
   entschuldigteJugendlicherIds: entschuldigteIds,
   undefinierteJugendlicherIds: undefinierteIds,
+  isSigned: false,
 );
 
 Kategorie _kategorie(String id) => Kategorie(id: id, name: 'Test Kategorie');

--- a/test/view_model/dashboard_viewmodel_test.dart
+++ b/test/view_model/dashboard_viewmodel_test.dart
@@ -89,6 +89,7 @@ Eintrag _eintrag({
   anwesendeJugendlicherIds: anwesendeIds,
   entschuldigteJugendlicherIds: const {},
   undefinierteJugendlicherIds: const {},
+  isSigned: false,
 );
 
 Kategorie _kategorie(String id) => Kategorie(id: id, name: 'Kategorie $id');


### PR DESCRIPTION
Closes #206

## Summary

- Extends `_getAllEintraegeSql` in `jldb` with a `LEFT JOIN` on the `signature` table to cheaply detect whether an Eintrag has any signatures — no crypto verification required
- Threads `isSigned: bool` through `EintragApiModel` → `Eintrag` → `SmallEintrag`
- Updates the `ListItem` subtitle in `EintragScreen` to a `Row` with a small 16px icon and the date:
  - `Icons.edit` in amber for unsignierte (draft) Einträge
  - `Icons.verified` in default subtitle colour for signierte Einträge

## Test plan

- [ ] All 43 existing tests pass
- [ ] Unsignierter Eintrag zeigt `edit`-Icon in Amber im Subtitle
- [ ] Signierter Eintrag zeigt `verified`-Icon in Defaultfarbe im Subtitle
- [ ] Icon-Größe (16px) ist unauffällig und stört den Scan-Flow nicht

🤖 Generated with [Claude Code](https://claude.com/claude-code)