### PR TITLE
Add self-update feature with GitHub Releases integration

### DIFF
--- a/lib/provider/shared_pref/shared_pref.dart
+++ b/lib/provider/shared_pref/shared_pref.dart
@@ -13,7 +13,11 @@ SharedPreferencesWithCache sharedPreferences(Ref ref) {
 Future<SharedPreferencesWithCache> createSharedPreferences() {
   return SharedPreferencesWithCache.create(
     cacheOptions: const SharedPreferencesWithCacheOptions(
-      allowList: <String>{'theme_mode', JulogService.lastOpenedFileKey},
+      allowList: <String>{
+        'theme_mode',
+        JulogService.lastOpenedFileKey,
+        'update_last_checked',
+      },
     ),
   );
 }

--- a/lib/ui/mainnav/shell.dart
+++ b/lib/ui/mainnav/shell.dart
@@ -4,6 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../provider/darkmode/darkmode.dart';
 import '../../provider/jldb/jldb.dart';
 import '../../provider/jldb/julog_file.dart';
+import '../../update/update_banner.dart';
+import '../../update/update_service.dart';
+import '../../update/update_state.dart';
 import '../widgets/about.dart';
 import '../widgets/theme_button.dart';
 import 'destination.dart';
@@ -17,47 +20,69 @@ class Shell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final mode = ref.watch(themeModeProvider);
     final julogFile = ref.watch(julogServiceProvider);
+
+    ref.listen(updateServiceProvider, (_, next) {
+      if (!context.mounted) return;
+      if (next case AsyncData(:final value)) {
+        if (value case UpdateStateReadyToInstall(
+          :final installerPath,
+          :final info,
+        )) {
+          showInstallConfirmDialog(context, ref, installerPath, info);
+        }
+      }
+    });
+
     return Scaffold(
-      body: Row(
+      body: Column(
         children: [
-          NavigationRail(
-            backgroundColor: Theme.of(context).colorScheme.surfaceDim,
-            destinations: Destination.values
-                .map((e) => e.railDestination)
-                .toList(),
-            onDestinationSelected: (value) {
-              final destination = Destination.values[value];
-              destination.route().go(context);
-            },
-            selectedIndex: destination.index,
-            labelType: NavigationRailLabelType.all,
-            leadingAtTop: true,
-            trailingAtBottom: true,
-            trailing: Column(
-              mainAxisSize: MainAxisSize.min,
+          const UpdateBanner(),
+          Expanded(
+            child: Row(
               children: [
-                ThemeButton(
-                  mode: mode,
-                  onPressed: (newMode) {
-                    ref.read(themeModeProvider.notifier).setThemeMode(newMode);
+                NavigationRail(
+                  backgroundColor: Theme.of(context).colorScheme.surfaceDim,
+                  destinations: Destination.values
+                      .map((e) => e.railDestination)
+                      .toList(),
+                  onDestinationSelected: (value) {
+                    final destination = Destination.values[value];
+                    destination.route().go(context);
                   },
-                ),
-                const SizedBox(width: 8),
-                if (julogFile is JulogFileLoaded) ...[
-                  IconButton(
-                    onPressed: () {
-                      ref.read(julogServiceProvider.notifier).close();
-                    },
-                    icon: const Icon(Icons.logout),
-                    tooltip: 'Julog-Datei schließen',
+                  selectedIndex: destination.index,
+                  labelType: NavigationRailLabelType.all,
+                  leadingAtTop: true,
+                  trailingAtBottom: true,
+                  trailing: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ThemeButton(
+                        mode: mode,
+                        onPressed: (newMode) {
+                          ref
+                              .read(themeModeProvider.notifier)
+                              .setThemeMode(newMode);
+                        },
+                      ),
+                      const SizedBox(width: 8),
+                      if (julogFile is JulogFileLoaded) ...[
+                        IconButton(
+                          onPressed: () {
+                            ref.read(julogServiceProvider.notifier).close();
+                          },
+                          icon: const Icon(Icons.logout),
+                          tooltip: 'Julog-Datei schließen',
+                        ),
+                      ],
+                      const AboutButton(),
+                      const SizedBox(height: 16),
+                    ],
                   ),
-                ],
-                const AboutButton(),
-                const SizedBox(height: 16),
+                ),
+                Expanded(child: child),
               ],
             ),
           ),
-          Expanded(child: child),
         ],
       ),
     );

--- a/lib/ui/widgets/about.dart
+++ b/lib/ui/widgets/about.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../provider/logging/logging.dart';
 import '../../pubspec.g.dart';
+import '../../update/update_service.dart';
+import '../../update/update_state.dart';
 import 'logo.dart';
 
 class AboutButton extends ConsumerWidget {
@@ -52,6 +54,7 @@ void showJulogAbout(BuildContext context, {String? logPath}) {
         ),
       ),
       if (logFileExists) _LogFileSection(logPath: logPath),
+      const _UpdateSection(),
     ],
   );
 }
@@ -84,6 +87,58 @@ class _LogFileSection extends StatelessWidget {
             },
             icon: const Icon(Icons.copy, size: 16),
             label: const Text('Pfad kopieren'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UpdateSection extends ConsumerWidget {
+  const _UpdateSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final updateState = ref.watch(updateServiceProvider);
+
+    final statusText = switch (updateState) {
+      AsyncLoading() => 'Wird geprüft…',
+      AsyncData(:final value) => switch (value) {
+        UpdateStateIdle() => 'Julog ist aktuell (${Pubspec.version})',
+        UpdateStateUpdateAvailable(:final info) =>
+          'Version ${info.version} verfügbar',
+        UpdateStateDownloading(:final progress) =>
+          'Wird heruntergeladen… ${(progress * 100).toStringAsFixed(0)} %',
+        UpdateStateReadyToInstall(:final info) =>
+          'Version ${info.version} bereit zur Installation',
+        UpdateStateError() => 'Prüfung fehlgeschlagen',
+      },
+      _ => '',
+    };
+
+    final canCheck = switch (updateState) {
+      AsyncLoading() => false,
+      AsyncData(:final value) => value is! UpdateStateDownloading,
+      _ => true,
+    };
+
+    return Container(
+      padding: const EdgeInsets.only(top: 10.0),
+      constraints: BoxConstraints.loose(const Size.fromWidth(200)),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Updates', style: TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 4),
+          Text(statusText, style: const TextStyle(fontSize: 12)),
+          const SizedBox(height: 4),
+          TextButton.icon(
+            onPressed: canCheck
+                ? () =>
+                      ref.read(updateServiceProvider.notifier).checkForUpdate()
+                : null,
+            icon: const Icon(Icons.refresh, size: 16),
+            label: const Text('Auf Updates prüfen'),
           ),
         ],
       ),

--- a/lib/update/update_banner.dart
+++ b/lib/update/update_banner.dart
@@ -1,0 +1,179 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../pubspec.g.dart';
+import 'update_info.dart';
+import 'update_service.dart';
+import 'update_state.dart';
+
+class UpdateBanner extends ConsumerWidget {
+  const UpdateBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(updateServiceProvider);
+    return switch (state) {
+      AsyncData(:final value) => switch (value) {
+        UpdateStateUpdateAvailable(:final info) => _AvailableBanner(info: info),
+        UpdateStateDownloading(:final progress) => _DownloadingBanner(
+          progress: progress,
+        ),
+        _ => const SizedBox.shrink(),
+      },
+      _ => const SizedBox.shrink(),
+    };
+  }
+}
+
+class _AvailableBanner extends ConsumerWidget {
+  final UpdateInfo info;
+  const _AvailableBanner({required this.info});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isWindows = Platform.isWindows;
+    return MaterialBanner(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      content: Text('Version ${info.version} verfügbar'),
+      actions: [
+        TextButton(
+          onPressed: () => ref
+              .read(updateServiceProvider.notifier)
+              .resetToUpdateAvailable(info),
+          child: const Text('Später'),
+        ),
+        FilledButton(
+          onPressed: () {
+            if (isWindows) {
+              ref.read(updateServiceProvider.notifier).startDownload(info);
+            } else {
+              ref.read(updateServiceProvider.notifier).openReleasesPage();
+            }
+          },
+          child: Text(isWindows ? 'Herunterladen' : 'Zur Download-Seite'),
+        ),
+      ],
+    );
+  }
+}
+
+class _DownloadingBanner extends StatelessWidget {
+  final double progress;
+  const _DownloadingBanner({required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (progress * 100).toStringAsFixed(0);
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Update wird heruntergeladen… $percent %',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 4),
+            LinearProgressIndicator(value: progress),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+void showInstallConfirmDialog(
+  BuildContext context,
+  WidgetRef ref,
+  String installerPath,
+  UpdateInfo info,
+) {
+  showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => PopScope(
+      canPop: false,
+      child: _InstallConfirmDialog(
+        installerPath: installerPath,
+        info: info,
+        ref: ref,
+      ),
+    ),
+  );
+}
+
+class _InstallConfirmDialog extends StatelessWidget {
+  final String installerPath;
+  final UpdateInfo info;
+  final WidgetRef ref;
+
+  const _InstallConfirmDialog({
+    required this.installerPath,
+    required this.info,
+    required this.ref,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Update bereit: ${info.version}'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 400),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Julog ${Pubspec.version} → ${info.version}',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Julog wird beendet, aktualisiert und automatisch neu gestartet.',
+            ),
+            if (info.releaseNotes case final notes? when notes.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              const Divider(),
+              const Text(
+                'Änderungen',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: Text(
+                    notes,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+            ref
+                .read(updateServiceProvider.notifier)
+                .resetToUpdateAvailable(info);
+          },
+          child: const Text('Später'),
+        ),
+        FilledButton(
+          onPressed: () =>
+              ref.read(updateServiceProvider.notifier).install(installerPath),
+          child: const Text('Jetzt installieren'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/update/update_info.dart
+++ b/lib/update/update_info.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'update_info.freezed.dart';
+
+@freezed
+abstract class UpdateInfo with _$UpdateInfo {
+  const factory UpdateInfo({
+    required String version,
+    required String tagName,
+    String? downloadUrl,
+    String? releaseNotes,
+  }) = _UpdateInfo;
+}

--- a/lib/update/update_service.dart
+++ b/lib/update/update_service.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../provider/shared_pref/shared_pref.dart';
+import '../pubspec.g.dart';
+import 'update_info.dart';
+import 'update_state.dart';
+
+part 'update_service.g.dart';
+
+@Riverpod(keepAlive: true)
+class UpdateService extends _$UpdateService {
+  static const String _lastCheckedKey = 'update_last_checked';
+  static const int _rateLimitMs = 24 * 60 * 60 * 1000;
+  static const String _apiUrl =
+      'https://api.github.com/repos/pbarbenheim/julog/releases/latest';
+  static const String _releasesPageUrl =
+      'https://github.com/pbarbenheim/julog/releases/latest';
+  static const String _windowsAssetName = 'julog-windows-x64-setup.exe';
+
+  @override
+  Future<UpdateState> build() {
+    final prefs = ref.read(sharedPreferencesProvider);
+    return _checkWithRateLimit(prefs);
+  }
+
+  Future<void> checkForUpdate() async {
+    state = const AsyncLoading();
+    final prefs = ref.read(sharedPreferencesProvider);
+    state = AsyncData(await _performCheck(prefs));
+  }
+
+  Future<void> startDownload(UpdateInfo info) async {
+    if (!Platform.isWindows || info.downloadUrl == null) return;
+
+    final tempDir = await getTemporaryDirectory();
+    final file = File(
+      '${tempDir.path}${Platform.pathSeparator}julog_update_${info.version}.exe',
+    );
+
+    // Re-use a previously downloaded installer if still present
+    if (file.existsSync()) {
+      state = AsyncData(
+        UpdateState.readyToInstall(installerPath: file.path, info: info),
+      );
+      return;
+    }
+
+    state = const AsyncData(UpdateState.downloading(0));
+    final client = http.Client();
+    try {
+      final response = await client.send(
+        http.Request('GET', Uri.parse(info.downloadUrl!)),
+      );
+      final contentLength = response.contentLength ?? 0;
+      final sink = file.openWrite();
+      int received = 0;
+      await response.stream
+          .map((chunk) {
+            received += chunk.length;
+            if (contentLength > 0) {
+              state = AsyncData(
+                UpdateState.downloading(received / contentLength),
+              );
+            }
+            return chunk;
+          })
+          .pipe(sink);
+      await sink.flush();
+      await sink.close();
+      state = AsyncData(
+        UpdateState.readyToInstall(installerPath: file.path, info: info),
+      );
+    } catch (_) {
+      state = const AsyncData(UpdateState.error('Download fehlgeschlagen'));
+    } finally {
+      client.close();
+    }
+  }
+
+  Future<void> install(String installerPath) async {
+    await Process.start(installerPath, [
+      '/SILENT',
+      '/SUPPRESSMSGBOXES',
+      '/NORESTART',
+    ], mode: ProcessStartMode.detached);
+    exit(0);
+  }
+
+  void openReleasesPage() {
+    if (Platform.isLinux) Process.start('xdg-open', [_releasesPageUrl]);
+    if (Platform.isMacOS) Process.start('open', [_releasesPageUrl]);
+  }
+
+  void resetToUpdateAvailable(UpdateInfo info) {
+    state = AsyncData(UpdateState.updateAvailable(info));
+  }
+
+  Future<UpdateState> _checkWithRateLimit(
+    SharedPreferencesWithCache prefs,
+  ) async {
+    final lastChecked = prefs.getInt(_lastCheckedKey);
+    if (lastChecked != null) {
+      final elapsed = DateTime.now().millisecondsSinceEpoch - lastChecked;
+      if (elapsed < _rateLimitMs) return const UpdateState.idle();
+    }
+    return _performCheck(prefs);
+  }
+
+  Future<UpdateState> _performCheck(SharedPreferencesWithCache prefs) async {
+    try {
+      final info = await _fetchLatestRelease();
+      await prefs.setInt(
+        _lastCheckedKey,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+      if (info == null) return const UpdateState.idle();
+      return UpdateState.updateAvailable(info);
+    } catch (_) {
+      return const UpdateState.idle();
+    }
+  }
+
+  Future<UpdateInfo?> _fetchLatestRelease() async {
+    final response = await http
+        .get(
+          Uri.parse(_apiUrl),
+          headers: {'Accept': 'application/vnd.github+json'},
+        )
+        .timeout(const Duration(seconds: 10));
+    if (response.statusCode != 200) return null;
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final tagName = json['tag_name'] as String? ?? '';
+    if (!_isNewer(tagName)) return null;
+
+    final version = tagName.replaceFirst('v', '');
+    final releaseNotes = json['body'] as String?;
+
+    String? downloadUrl;
+    if (Platform.isWindows) {
+      final assets = json['assets'] as List<dynamic>? ?? [];
+      for (final asset in assets) {
+        if (asset is Map<String, dynamic> &&
+            asset['name'] == _windowsAssetName) {
+          downloadUrl = asset['browser_download_url'] as String?;
+          break;
+        }
+      }
+    }
+
+    return UpdateInfo(
+      version: version,
+      tagName: tagName,
+      downloadUrl: downloadUrl,
+      releaseNotes: releaseNotes,
+    );
+  }
+
+  bool _isNewer(String tagName) {
+    final parts = tagName
+        .replaceFirst('v', '')
+        .split('.')
+        .map(int.tryParse)
+        .toList();
+    if (parts.length < 3 || parts.any((e) => e == null)) return false;
+    final major = parts[0]!;
+    final minor = parts[1]!;
+    final patch = parts[2]!;
+    if (major != Pubspec.versionMajor) return major > Pubspec.versionMajor;
+    if (minor != Pubspec.versionMinor) return minor > Pubspec.versionMinor;
+    return patch > Pubspec.versionPatch;
+  }
+}

--- a/lib/update/update_state.dart
+++ b/lib/update/update_state.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'update_info.dart';
+
+part 'update_state.freezed.dart';
+
+@freezed
+sealed class UpdateState with _$UpdateState {
+  const factory UpdateState.idle() = UpdateStateIdle;
+  const factory UpdateState.updateAvailable(UpdateInfo info) =
+      UpdateStateUpdateAvailable;
+  const factory UpdateState.downloading(double progress) =
+      UpdateStateDownloading;
+  const factory UpdateState.readyToInstall({
+    required String installerPath,
+    required UpdateInfo info,
+  }) = UpdateStateReadyToInstall;
+  const factory UpdateState.error(String message) = UpdateStateError;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -526,7 +526,7 @@ packages:
     source: hosted
     version: "0.15.6"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   logging: ^1.2.0
   path_provider: ^2.1.0
+  http: ^1.2.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/innosetup/setup.iss
+++ b/windows/innosetup/setup.iss
@@ -1,7 +1,7 @@
 [Files]
 Source: "..\..\build\windows\x64\runner\Release\*"; Excludes: "*.zip"; DestDir: "{app}"; Flags: recursesubdirs
-Source: "..\..\LICENSE"; DestDir: "{app}"; Flags: isreadme
-Source: "..\..\README.md"; DestDir: "{app}"; Flags: isreadme
+Source: "..\..\LICENSE"; DestDir: "{app}"
+Source: "..\..\README.md"; DestDir: "{app}"
 
 [Setup]
 AppName=Julog
@@ -11,6 +11,7 @@ DefaultGroupName=Julog
 ChangesAssociations=yes
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
+CloseApplications=yes
 
 [Icons]
 Name: "{group}\Julog"; Filename: "{app}\julog.exe"; WorkingDir: "{app}"
@@ -34,3 +35,8 @@ Root: HKCR; Subkey: "JFDB.File\shell\open"; ValueType: string; \
   ValueName: ""; ValueData: "Mit Julog öffnen"
 Root: HKCR; Subkey: "JFDB.File\shell"; ValueType: string; \
   ValueName: ""; ValueData: "open"
+
+[Run]
+Filename: "{app}\julog.exe"; Description: "Julog starten"; \
+  Flags: postinstall nowait skipifsilent
+Filename: "{app}\julog.exe"; Flags: nowait; Check: WizardSilent


### PR DESCRIPTION
## Summary

- Checks GitHub Releases API at app startup (rate-limited to once per 24h) and shows a banner when a newer version is available
- **Windows**: downloads `julog-windows-x64-setup.exe` to the temp directory with a progress indicator, then launches the installer as a detached process (`/SILENT /SUPPRESSMSGBOXES /NORESTART`) and exits — InnoSetup restarts Julog automatically via the new `[Run]` section
- **Linux/macOS**: opens the GitHub releases page in the browser instead
- A blocking confirmation dialog (cannot be dismissed by clicking outside or pressing Escape) appears after the download completes, showing the version delta and release notes before the user confirms the install
- "Auf Updates prüfen" button added to the About dialog with live status

## InnoSetup changes

- `CloseApplications=yes` — uses Windows Restart Manager to close Julog if still running when the installer reaches file replacement
- `[Run]` section with two entries: checkbox on the final wizard page for normal installs; automatic launch after silent installs (self-update flow)
- `isreadme` flags removed from LICENSE and README.md — files are still copied to `{app}` but no longer offered for viewing at the end of setup

## Test plan

- [ ] Build Windows release and create a GitHub draft release with `julog-windows-x64-setup.exe` asset at a higher version number
- [ ] Clear `update_last_checked` from SharedPreferences (or set it to 0) and launch the app — banner should appear
- [ ] Click "Herunterladen", watch progress bar, confirm blocking dialog appears with release notes
- [ ] Click "Jetzt installieren" — Julog closes, installer runs silently, Julog reopens at new version
- [ ] Click "Später" — dialog closes, banner reappears; clicking "Herunterladen" again skips re-download if temp file still exists
- [ ] "Auf Updates prüfen" in About dialog triggers a manual check ignoring the rate limit
- [ ] On Linux/macOS: banner shows "Zur Download-Seite", clicking opens browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)